### PR TITLE
Allow applying multiple filters on instances with #apply_filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ discretize = Discretize.new
 
 # apply a filter chain on instances
 filtered_data = instances.apply_filter(normalize).apply_filter(discretize)
+
+# or even shorter
+filtered_data = instances.apply_filters(normalize, discretize)
 ```
 
 #### Setting Filter options

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -163,6 +163,12 @@ module Weka
         filter.filter(self)
       end
 
+      def apply_filters(*filters)
+        filters.inject(self) do |filtered_instances, filter|
+          filter.filter(filtered_instances)
+        end
+      end
+
       private
 
       def add_attribute(attribute)

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -25,6 +25,7 @@ describe Weka::Core::Instances do
 
   it { is_expected.to respond_to :add_instance }
   it { is_expected.to respond_to :apply_filter }
+  it { is_expected.to respond_to :apply_filters }
 
   it { is_expected.to respond_to :class_attribute= }
   it { is_expected.to respond_to :class_attribute }
@@ -441,9 +442,19 @@ describe Weka::Core::Instances do
     let(:filter) { double('filter') }
     before { allow(filter).to receive(:filter).and_return(subject) }
 
-    it 'should call the given filters #filter method' do
+    it 'should call the given filter‘s #filter method' do
       expect(filter).to receive(:filter).once.with(subject)
       subject.apply_filter(filter)
+    end
+  end
+
+  describe '#apply_filters' do
+    let(:filter) { double('filter') }
+    before { allow(filter).to receive(:filter).and_return(subject) }
+
+    it 'should call the given filters‘ #filter methods' do
+      expect(filter).to receive(:filter).twice.with(subject)
+      subject.apply_filters(filter, filter)
     end
   end
 


### PR DESCRIPTION
Allows to apply multiple filters on an Instances object:

```ruby
filtered_data = instances.apply_filters(filter, other_filter, yet_another_filter, ...)
```

Fixes #1.

