### PR TITLE
Enable missing values in instances

### DIFF
--- a/lib/weka/core/attribute.rb
+++ b/lib/weka/core/attribute.rb
@@ -11,14 +11,14 @@ module Weka
       # The order of the if statements is important here, because a date is also
       # a numeric.
       def internal_value_of(value)
-        if date?
-          parse_date(value.to_s)
-        elsif numeric?
-          value.to_f
-        elsif nominal?
-          index_of_value(value.to_s)
-        end
+        return value                      if value === Float::NAN
+        return Float::NAN                 if [nil, '?'].include?(value)
+        return parse_date(value.to_s)     if date?
+        return value.to_f                 if numeric?
+        return index_of_value(value.to_s) if nominal?
       end
     end
+
+    Weka::Core::Attribute.__persistent__ = true
   end
 end

--- a/lib/weka/core/dense_instance.rb
+++ b/lib/weka/core/dense_instance.rb
@@ -7,7 +7,11 @@ module Weka
       java_import "java.text.SimpleDateFormat"
 
       def initialize(data, weight: 1.0)
-        super(weight, data.to_java(:double))
+        if data.kind_of?(Integer)
+          super(data)
+        else
+          super(weight, data.to_java(:double))
+        end
       end
 
       def attributes
@@ -30,15 +34,7 @@ module Weka
 
       def to_a
         to_double_array.each_with_index.map do |value, index|
-          attribute = attribute_at(index)
-
-          if attribute.date?
-            format_date(value, attribute.date_format)
-          elsif attribute.numeric?
-            value
-          elsif attribute.nominal?
-            attribute.value(value)
-          end
+          value_from(value, index)
         end
       end
 
@@ -46,6 +42,21 @@ module Weka
       alias :values_count :num_values
 
       private
+
+      def value_from(value, index)
+        return '?'   if value.nan?
+        return value if dataset.nil?
+
+        attribute = attribute_at(index)
+
+        if attribute.date?
+          format_date(value, attribute.date_format)
+        elsif attribute.numeric?
+          value
+        elsif attribute.nominal?
+          attribute.value(value)
+        end
+      end
 
       def attribute_at(index)
         return attributes[index] unless dataset.class_attribute_defined?

--- a/lib/weka/core/dense_instance.rb
+++ b/lib/weka/core/dense_instance.rb
@@ -10,7 +10,7 @@ module Weka
         if data.kind_of?(Integer)
           super(data)
         else
-          super(weight, data.to_java(:double))
+          super(weight, to_java_double(data))
         end
       end
 
@@ -42,6 +42,14 @@ module Weka
       alias :values_count :num_values
 
       private
+
+      def to_java_double(values)
+        data = values.map do |value|
+          ['?', nil].include?(value) ? Float::NAN : value
+        end
+
+        data.to_java(:double)
+      end
 
       def value_from(value, index)
         return '?'   if value.nan?

--- a/spec/core/attribute_spec.rb
+++ b/spec/core/attribute_spec.rb
@@ -25,6 +25,18 @@ describe Weka::Core::Attribute do
       it 'should return the value as a float if given as string' do
         expect(attribute.internal_value_of('3.5')).to eq 3.5
       end
+
+      it 'should return NaN if the given value is Float::NAN' do
+        expect(attribute.internal_value_of(Float::NAN)).to be Float::NAN
+      end
+
+      it 'should return NaN if the given value is nil' do
+        expect(attribute.internal_value_of(nil)).to be Float::NAN
+      end
+
+      it 'should return NaN if the given value is "?"' do
+        expect(attribute.internal_value_of("?")).to be Float::NAN
+      end
     end
 
     context 'a nominal attribute' do
@@ -42,6 +54,18 @@ describe Weka::Core::Attribute do
         expect(attribute.internal_value_of(:true)).to eq 0
         expect(attribute.internal_value_of(:false)).to eq 1
       end
+
+      it 'should return NaN if the given value is Float::NAN' do
+        expect(attribute.internal_value_of(Float::NAN)).to be Float::NAN
+      end
+
+      it 'should return NaN if the given value is nil' do
+        expect(attribute.internal_value_of(nil)).to be Float::NAN
+      end
+
+      it 'should return NaN if the given value is "?"' do
+        expect(attribute.internal_value_of("?")).to be Float::NAN
+      end
     end
 
     context 'a data attribute' do
@@ -58,6 +82,18 @@ describe Weka::Core::Attribute do
 
       it 'should return the right date timestamp value' do
         expect(attribute.internal_value_of(datetime)).to eq unix_timestamp
+      end
+
+      it 'should return NaN if the given value is Float::NAN' do
+        expect(attribute.internal_value_of(Float::NAN)).to be Float::NAN
+      end
+
+      it 'should return NaN if the given value is nil' do
+        expect(attribute.internal_value_of(nil)).to be Float::NAN
+      end
+
+      it 'should return NaN if the given value is "?"' do
+        expect(attribute.internal_value_of("?")).to be Float::NAN
       end
     end
   end

--- a/spec/core/dense_instance_spec.rb
+++ b/spec/core/dense_instance_spec.rb
@@ -28,13 +28,20 @@ describe Weka::Core::DenseInstance do
   describe 'instantiation' do
     describe 'with an Integer value' do
       it 'should create a instance with only missing values' do
-        expect(Weka::Core::DenseInstance.new(2).values).to eq ['?', '?']
+        values = Weka::Core::DenseInstance.new(2).values
+        expect(values).to eq ['?', '?']
       end
     end
 
     describe 'with an array' do
       it 'should create an instance with the given values' do
-        expect(Weka::Core::DenseInstance.new([1, 2, 3]).values).to eq [1, 2, 3]
+        values = Weka::Core::DenseInstance.new([1, 2, 3]).values
+        expect(values).to eq [1, 2, 3]
+      end
+
+      it 'should handle "?" values or nil values' do
+        values = Weka::Core::DenseInstance.new([1, '?', nil, 4]).values
+        expect(values).to eq [1, '?', '?', 4]
       end
     end
   end

--- a/spec/core/dense_instance_spec.rb
+++ b/spec/core/dense_instance_spec.rb
@@ -25,6 +25,20 @@ describe Weka::Core::DenseInstance do
     end
   end
 
+  describe 'instantiation' do
+    describe 'with an Integer value' do
+      it 'should create a instance with only missing values' do
+        expect(Weka::Core::DenseInstance.new(2).values).to eq ['?', '?']
+      end
+    end
+
+    describe 'with an array' do
+      it 'should create an instance with the given values' do
+        expect(Weka::Core::DenseInstance.new([1, 2, 3]).values).to eq [1, 2, 3]
+      end
+    end
+  end
+
   describe '#to_a' do
     let(:values) { ['rainy',50.0, 50.0,'TRUE','no','2015-12-24 11:11'] }
 

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -412,6 +412,19 @@ describe Weka::Core::Instances do
 
       expect(subject.instances.last.to_s).to eq data.to_s
     end
+
+    it 'should add a given instance with only missing values' do
+      data = Weka::Core::DenseInstance.new(subject.size)
+      subject.add_instance(data)
+      expect(subject.instances.last.to_s).to eq data.to_s
+    end
+
+    it 'should add a given instance with partly missing values' do
+      data = [:sunny, 70, nil, '?', Float::NAN]
+      subject.add_instance(data)
+
+      expect(subject.instances.last.to_s).to eq 'sunny,70,?,?,?'
+    end
   end
 
   describe '#add_instances' do


### PR DESCRIPTION
Allows creating `Weka::Core::DenseInstance` objects by instantiation with just an integer (additionally to the initializer with a data array and the weight):

```ruby
Weka::Core::DenseInstance.new(5)
```
creates an instance with 5 missing values.

Fixes internal type casting of allowed missing values (`'?'`, `nil`, and `Float::NAN`) in an Attribute in order to allow adding instances with missing values:

```ruby
# instances is a Weka::Core::Instances object
instances.add_instance([:sunny, '?', 75, nil, Float::NAN])
instances.instances.last.values
# => ['sunny', '?', 75, '?', '?']
```