### PR TITLE
Code and specs cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ cache:
   - bundler
 
 before_install:
-  - gem install bundler
   - rvm get head
   - rvm use jruby-9.0.1.0 --install
+  - gem install bundler
 
 script: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The weka gem tries to carry over the namespaces defined in Weka and enhances som
 
 The idea behind keeping the namespaces is, that you can also use the [Weka documentation](http://weka.sourceforge.net/doc.dev/) for looking up functionality and classes.
 
-Please refer to [the gem‘s Wiki](https://github.com/paulgoetze/weka-jruby/wiki) for
+Please refer to [the gem’s Wiki](https://github.com/paulgoetze/weka-jruby/wiki) for
 detailed information about how to use weka with JRuby and some examplary code snippets.
 
 ## Development
@@ -49,7 +49,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/paulgo
 
 For development we use the [git branching model](http://nvie.com/posts/a-successful-git-branching-model/) described by [nvie](https://github.com/nvie).
 
-Here's how to contribute:
+Here’s how to contribute:
 
 1. Fork it ( https://github.com/paulgoetze/weka-jruby/fork )
 2. Create your feature branch (`git checkout -b feature/my-new-feature develop`)

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :prepare
-task :install => :prepare
+task default: :prepare
+task install: :prepare
 
 desc 'Install weka jars & dependencies'
 task :prepare do
@@ -15,7 +15,7 @@ task :prepare do
   LockJar.install('Jarfile.lock', local_repo: jars_dir)
 end
 
-desc "Start an irb session with the gem loaded"
+desc 'Start an irb session with the gem loaded'
 task :irb do
   sh 'irb -I ./lib -r weka'
 end

--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "weka"
+require 'bundler/setup'
+require 'weka'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
+# require 'pry'
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/lib/weka/attribute_selection/attribute_selection.rb
+++ b/lib/weka/attribute_selection/attribute_selection.rb
@@ -3,9 +3,8 @@ module Weka
     java_import 'weka.attributeSelection.AttributeSelection'
 
     class AttributeSelection
-
-      alias :summary :to_results_string
-      alias :selected_attributes_count :number_attributes_selected
+      alias summary to_results_string
+      alias selected_attributes_count number_attributes_selected
     end
   end
 end

--- a/lib/weka/class_builder.rb
+++ b/lib/weka/class_builder.rb
@@ -8,7 +8,6 @@ module Weka
     extend ActiveSupport::Concern
 
     module ClassMethods
-
       def build_class(class_name, weka_module: nil, include_concerns: true)
         java_import java_class_path(class_name, weka_module)
         define_class(class_name, weka_module, include_concerns: include_concerns)
@@ -37,7 +36,7 @@ module Weka
       end
 
       def super_modules
-        toplevel_module? ? self.name : self.name.deconstantize
+        toplevel_module? ? name : name.deconstantize
       end
 
       def java_including_module
@@ -45,11 +44,11 @@ module Weka
       end
 
       def including_module
-        self.name.demodulize unless toplevel_module?
+        name.demodulize unless toplevel_module?
       end
 
       def toplevel_module?
-        self.name.scan('::').count == 1
+        name.scan('::').count == 1
       end
 
       def define_class(class_name, weka_module, include_concerns: true)
@@ -66,7 +65,7 @@ module Weka
         class_path   = java_class_path(class_name, weka_module)
         serializable = Weka::Core::SerializationHelper.serializable?(class_path)
 
-        "include Weka::Concerns::Serializable" if serializable
+        'include Weka::Concerns::Serializable' if serializable
       end
 
       def include_utils
@@ -91,6 +90,5 @@ module Weka
         string[0].downcase + string[1..-1]
       end
     end
-
   end
 end

--- a/lib/weka/classifiers/evaluation.rb
+++ b/lib/weka/classifiers/evaluation.rb
@@ -3,35 +3,33 @@ module Weka
     java_import 'weka.classifiers.Evaluation'
 
     class Evaluation
-
       # Use both nomenclatures f_measure and fmeasure for consistency
       # due to jruby's auto method generation of 'fMeasure' to 'f_measure' and
       # 'weightedFMeasure' to 'weighted_fmeasure'.
-      alias :weighted_f_measure       :weighted_fmeasure
-      alias :fmeasure                 :f_measure
+      alias weighted_f_measure      weighted_fmeasure
+      alias fmeasure                f_measure
 
-      alias :summary                  :to_summary_string
-      alias :class_details            :to_class_details_string
+      alias summary                 to_summary_string
+      alias class_details           to_class_details_string
 
-      alias :instance_count           :num_instances
-      alias :correct_count            :correct
-      alias :incorrect_count          :incorrect
-      alias :unclassified_count       :unclassified
+      alias instance_count          num_instances
+      alias correct_count           correct
+      alias incorrect_count         incorrect
+      alias unclassified_count      unclassified
 
-      alias :correct_percentage       :pct_correct
-      alias :incorrect_percentage     :pct_incorrect
-      alias :unclassified_percentage  :pct_unclassified
+      alias correct_percentage      pct_correct
+      alias incorrect_percentage    pct_incorrect
+      alias unclassified_percentage pct_unclassified
 
-      alias :true_negative_count      :num_true_negatives
-      alias :false_negative_count     :num_false_negatives
-      alias :true_positive_count      :num_true_positives
-      alias :false_positive_count     :num_false_positives
-      alias :average_cost             :avg_cost
+      alias true_negative_count     num_true_negatives
+      alias false_negative_count    num_false_negatives
+      alias true_positive_count     num_true_positives
+      alias false_positive_count    num_false_positives
+      alias average_cost            avg_cost
 
-      alias :cumulative_margin_distribution :to_cumulative_margin_distribution_string
+      alias cumulative_margin_distribution to_cumulative_margin_distribution_string
     end
 
     Java::WekaClassifiers::Evaluation.__persistent__ = true
-
   end
 end

--- a/lib/weka/classifiers/utils.rb
+++ b/lib/weka/classifiers/utils.rb
@@ -63,7 +63,7 @@ module Weka
           end
 
           def add_training_data(data)
-            values   = self.training_instances.internal_values_of(data)
+            values   = training_instances.internal_values_of(data)
             instance = Weka::Core::DenseInstance.new(values)
             add_training_instance(instance)
           end
@@ -132,7 +132,6 @@ module Weka
           end
         end
       end
-
     end
   end
 end

--- a/lib/weka/clusterers/cluster_evaluation.rb
+++ b/lib/weka/clusterers/cluster_evaluation.rb
@@ -3,12 +3,10 @@ module Weka
     java_import 'weka.clusterers.ClusterEvaluation'
 
     class ClusterEvaluation
-
-      alias :summary        :cluster_results_to_string
-      alias :clusters_count :num_clusters
+      alias summary        cluster_results_to_string
+      alias clusters_count num_clusters
     end
 
     Java::WekaClusterers::ClusterEvaluation.__persistent__ = true
-
   end
 end

--- a/lib/weka/clusterers/utils.rb
+++ b/lib/weka/clusterers/utils.rb
@@ -61,7 +61,7 @@ module Weka
           end
 
           def add_training_data(data)
-            values   = self.training_instances.internal_values_of(data)
+            values   = training_instances.internal_values_of(data)
             instance = Weka::Core::DenseInstance.new(values)
             add_training_instance(instance)
           end
@@ -96,8 +96,6 @@ module Weka
           instances.first
         end
       end
-
     end
   end
 end
-

--- a/lib/weka/concerns/buildable.rb
+++ b/lib/weka/concerns/buildable.rb
@@ -6,14 +6,12 @@ module Weka
       extend ActiveSupport::Concern
 
       module ClassMethods
-
         def build(&block)
           instance = new
           instance.instance_eval(&block) if block_given?
           instance
         end
       end
-
     end
   end
 end

--- a/lib/weka/concerns/describable.rb
+++ b/lib/weka/concerns/describable.rb
@@ -6,7 +6,6 @@ module Weka
       extend ActiveSupport::Concern
 
       module ClassMethods
-
         def description
           new.global_info
         end

--- a/lib/weka/concerns/optionizable.rb
+++ b/lib/weka/concerns/optionizable.rb
@@ -6,7 +6,7 @@ module Weka
       extend ActiveSupport::Concern
 
       included do
-        java_import "weka.core.Utils"
+        java_import 'weka.core.Utils'
 
         def use_options(*single_options, **hash_options)
           joined_options = join_options(single_options, hash_options)
@@ -43,7 +43,6 @@ module Weka
           new.get_options.to_a.join(' ')
         end
       end
-
     end
   end
 end

--- a/lib/weka/concerns/persistent.rb
+++ b/lib/weka/concerns/persistent.rb
@@ -6,11 +6,8 @@ module Weka
       extend ActiveSupport::Concern
 
       included do
-        if self.respond_to?(:__persistent__=)
-          self.__persistent__ = true
-        end
+        self.__persistent__ = true if respond_to?(:__persistent__=)
       end
-
     end
   end
 end

--- a/lib/weka/concerns/serializable.rb
+++ b/lib/weka/concerns/serializable.rb
@@ -11,7 +11,6 @@ module Weka
           Weka::Core::SerializationHelper.write(filename, self)
         end
       end
-
     end
   end
 end

--- a/lib/weka/core/attribute.rb
+++ b/lib/weka/core/attribute.rb
@@ -1,9 +1,8 @@
 module Weka
   module Core
-    java_import "weka.core.Attribute"
+    java_import 'weka.core.Attribute'
 
     class Attribute
-
       def values
         enumerate_values.to_a
       end

--- a/lib/weka/core/dense_instance.rb
+++ b/lib/weka/core/dense_instance.rb
@@ -1,13 +1,13 @@
 module Weka
   module Core
-    java_import "weka.core.DenseInstance"
+    java_import 'weka.core.DenseInstance'
 
     class DenseInstance
-      java_import "java.util.Date"
-      java_import "java.text.SimpleDateFormat"
+      java_import 'java.util.Date'
+      java_import 'java.text.SimpleDateFormat'
 
       def initialize(data, weight: 1.0)
-        if data.kind_of?(Integer)
+        if data.is_a?(Integer)
           super(data)
         else
           super(weight, to_java_double(data))
@@ -38,8 +38,8 @@ module Weka
         end
       end
 
-      alias :values       :to_a
-      alias :values_count :num_values
+      alias values       to_a
+      alias values_count num_values
 
       private
 

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -6,13 +6,13 @@ require 'weka/concerns/serializable'
 
 module Weka
   module Core
-    java_import "weka.core.Instances"
-    java_import "weka.core.FastVector"
+    java_import 'weka.core.Instances'
+    java_import 'weka.core.FastVector'
 
     class Instances
       include Weka::Concerns::Serializable
 
-      DEFAULT_RELATION_NAME = 'Instances'
+      DEFAULT_RELATION_NAME = 'Instances'.freeze
 
       class << self
         def from_arff(file)
@@ -48,13 +48,13 @@ module Weka
       end
 
       def add_attributes(&block)
-        self.instance_eval(&block) if block
+        instance_eval(&block) if block
         self
       end
 
-      alias :with_attributes  :add_attributes
-      alias :instances_count  :num_instances
-      alias :attributes_count :num_attributes
+      alias with_attributes  add_attributes
+      alias instances_count  num_instances
+      alias attributes_count num_attributes
 
       def each
         if block_given?
@@ -129,10 +129,10 @@ module Weka
         end
       end
 
-      alias :add_numeric_attribute :numeric
-      alias :add_string_attribute  :string
-      alias :add_nominal_attribute :nominal
-      alias :add_date_attribute    :date
+      alias add_numeric_attribute numeric
+      alias add_string_attribute  string
+      alias add_nominal_attribute nominal
+      alias add_date_attribute    date
 
       def class_attribute
         classAttribute if class_attribute_defined?
@@ -187,7 +187,7 @@ module Weka
         return if attribute_names.include?(name.to_s)
 
         error   = "\"#{name}\" is not defined."
-        hint    = "Only defined attributes can be used as class attribute!"
+        hint    = 'Only defined attributes can be used as class attribute!'
         message = "#{error} #{hint}"
 
         raise ArgumentError, message
@@ -198,7 +198,7 @@ module Weka
       end
 
       def instance_from(instance_or_values, weight:)
-        if instance_or_values.kind_of?(Java::WekaCore::Instance)
+        if instance_or_values.is_a?(Java::WekaCore::Instance)
           instance_or_values.weight = weight
           instance_or_values
         else

--- a/lib/weka/core/loader.rb
+++ b/lib/weka/core/loader.rb
@@ -27,6 +27,5 @@ module Weka
         end
       end
     end
-
   end
 end

--- a/lib/weka/core/saver.rb
+++ b/lib/weka/core/saver.rb
@@ -29,6 +29,5 @@ module Weka
         end
       end
     end
-
   end
 end

--- a/lib/weka/core/serialization_helper.rb
+++ b/lib/weka/core/serialization_helper.rb
@@ -3,10 +3,9 @@ module Weka
     java_import 'weka.core.SerializationHelper'
 
     class SerializationHelper
-
       class << self
-        alias :deserialize :read
-        alias :serialize   :write
+        alias deserialize read
+        alias serialize   write
       end
     end
   end

--- a/lib/weka/filters/filter.rb
+++ b/lib/weka/filters/filter.rb
@@ -4,6 +4,5 @@ module Weka
 
     class Filter
     end
-
   end
 end

--- a/lib/weka/filters/supervised/attribute.rb
+++ b/lib/weka/filters/supervised/attribute.rb
@@ -16,10 +16,9 @@ module Weka
                       :PartitionMembership
 
         class AttributeSelection
-          alias :use_evaluator :set_evaluator
-          alias :use_search    :set_search
+          alias use_evaluator set_evaluator
+          alias use_search    set_search
         end
-
       end
     end
   end

--- a/lib/weka/filters/utils.rb
+++ b/lib/weka/filters/utils.rb
@@ -11,7 +11,6 @@ module Weka
           Filter.use_filter(instances, self)
         end
       end
-
     end
   end
 end

--- a/lib/weka/jars.rb
+++ b/lib/weka/jars.rb
@@ -14,6 +14,5 @@ module Weka
       LockJar.install(lockfile, local_repo: jars_dir)
       LockJar.load(lockfile, local_repo: jars_dir)
     end
-
   end
 end

--- a/lib/weka/version.rb
+++ b/lib/weka/version.rb
@@ -1,3 +1,3 @@
 module Weka
-  VERSION = "0.3.0"
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/attribute_selection/attribute_selection_spec.rb
+++ b/spec/attribute_selection/attribute_selection_spec.rb
@@ -6,7 +6,7 @@ describe Weka::AttributeSelection::AttributeSelection do
       to_results_string:          :summary,
       number_attributes_selected: :selected_attributes_count
     }.each do |method, alias_method|
-      it "should define the alias ##{alias_method} for ##{method}" do
+      it "defines the alias ##{alias_method} for ##{method}" do
         expect(subject.method(method)).to eq subject.method(alias_method)
       end
     end

--- a/spec/attribute_selection/attribute_selection_spec.rb
+++ b/spec/attribute_selection/attribute_selection_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::AttributeSelection::AttributeSelection do
-
   describe 'aliases:' do
     {
       to_results_string:          :summary,

--- a/spec/attribute_selection/evaluator_spec.rb
+++ b/spec/attribute_selection/evaluator_spec.rb
@@ -15,11 +15,11 @@ describe Weka::AttributeSelection::Evaluator do
     :SymmetricalUncertAttribute => :SymmetricalUncertAttributeEval,
     :WrapperSubset              => :WrapperSubsetEval
   }.each do |class_name, super_class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(subject.const_defined?(class_name)).to be true
     end
 
-    it "should inherit class #{class_name} from #{super_class_name}" do
+    it "inherits class #{class_name} from #{super_class_name}" do
       evaluator_class = "#{subject}::#{class_name}".constantize
       super_class     = "#{subject}::#{super_class_name}".constantize
 
@@ -27,7 +27,7 @@ describe Weka::AttributeSelection::Evaluator do
     end
   end
 
-  it 'should define a class PrincipalComponents' do
+  it 'defines a class PrincipalComponents' do
     expect(subject.const_defined?(:PrincipalComponents)).to be true
   end
 end

--- a/spec/attribute_selection/evaluator_spec.rb
+++ b/spec/attribute_selection/evaluator_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::AttributeSelection::Evaluator do
-
   subject { described_class }
 
   it_behaves_like 'class builder'
@@ -28,7 +27,7 @@ describe Weka::AttributeSelection::Evaluator do
     end
   end
 
-  it "should define a class PrincipalComponents" do
-      expect(subject.const_defined?(:PrincipalComponents)).to be true
-    end
+  it 'should define a class PrincipalComponents' do
+    expect(subject.const_defined?(:PrincipalComponents)).to be true
+  end
 end

--- a/spec/attribute_selection/search_spec.rb
+++ b/spec/attribute_selection/search_spec.rb
@@ -10,7 +10,7 @@ describe Weka::AttributeSelection::Search do
     :Ranker,
     :BestFirst
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(subject.const_defined?(class_name)).to be true
     end
   end

--- a/spec/attribute_selection/search_spec.rb
+++ b/spec/attribute_selection/search_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::AttributeSelection::Search do
-
   subject { described_class }
 
   it_behaves_like 'class builder'

--- a/spec/attribute_selection_spec.rb
+++ b/spec/attribute_selection_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe Weka::AttributeSelection do
-
-  it "should define a class AttributeSelection" do
+  it 'should define a class AttributeSelection' do
     expect(described_class.const_defined?(:AttributeSelection)).to be true
   end
 end

--- a/spec/attribute_selection_spec.rb
+++ b/spec/attribute_selection_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Weka::AttributeSelection do
-  it 'should define a class AttributeSelection' do
+  it 'defines a class AttributeSelection' do
     expect(described_class.const_defined?(:AttributeSelection)).to be true
   end
 end

--- a/spec/class_builder_spec.rb
+++ b/spec/class_builder_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::ClassBuilder do
-
   subject do
     module Some
       module Weka
@@ -14,7 +13,7 @@ describe Weka::ClassBuilder do
     end
   end
 
-  let(:class_name){ :SomeClass }
+  let(:class_name) { :SomeClass }
 
   before { allow(subject).to receive(:java_import).and_return('') }
 
@@ -124,7 +123,7 @@ describe Weka::ClassBuilder do
   describe '.build_classes' do
     context 'without a given weka_module' do
       it 'should run .build_class for each of the given classes' do
-        class_names = %i{ SomeClass SomeOtherClass }
+        class_names = %i(SomeClass SomeOtherClass)
 
         expect(subject).to receive(:build_class).exactly(class_names.count).times
         subject.build_classes(*class_names)
@@ -133,7 +132,7 @@ describe Weka::ClassBuilder do
 
     context 'with a given weka_module' do
       it 'should run .build_class for each of the given classes' do
-        class_names = %i{ SomeClass SomeOtherClass }
+        class_names = %i(SomeClass SomeOtherClass)
 
         expect(subject).to receive(:build_class).exactly(class_names.count).times
         subject.build_classes(*class_names, weka_module: 'weka.module')

--- a/spec/class_builder_spec.rb
+++ b/spec/class_builder_spec.rb
@@ -18,13 +18,13 @@ describe Weka::ClassBuilder do
   before { allow(subject).to receive(:java_import).and_return('') }
 
   [:build_class, :build_classes].each do |method|
-    it "should define .#{method} if included" do
+    it "defines .#{method} if included" do
       expect(subject).to respond_to method
     end
   end
 
   describe '.build_class' do
-    it 'should run java_import with the right resolved class path' do
+    it 'runs java_import with the right resolved class path' do
       class_path = "some.weka.customCamelCased.module.#{class_name}"
 
       expect(subject).to receive(:java_import).once.with(class_path)
@@ -36,7 +36,7 @@ describe Weka::ClassBuilder do
 
       describe 'built class including Describable functionality' do
         Weka::Concerns::Describable::ClassMethods.instance_methods.each do |method|
-          it "should respond to .#{method}" do
+          it "responds to .#{method}" do
             expect(built_class).to respond_to method
           end
         end
@@ -44,7 +44,7 @@ describe Weka::ClassBuilder do
 
       describe 'built class including Buildable functionality' do
         Weka::Concerns::Buildable::ClassMethods.instance_methods.each do |method|
-          it "should respond to .#{method}" do
+          it "responds to .#{method}" do
             expect(built_class).to respond_to method
           end
         end
@@ -53,12 +53,12 @@ describe Weka::ClassBuilder do
       describe 'built class including Optionizable functionality' do
         let(:built_class_instance) { built_class.new }
 
-        it 'should respond to .default_options' do
+        it 'responds to .default_options' do
           expect(built_class).to respond_to :default_options
         end
 
         [:use_options, :options].each do |method|
-          it "should respond to ##{method}" do
+          it "responds to ##{method}" do
             expect(built_class_instance).to respond_to method
           end
         end
@@ -77,7 +77,7 @@ describe Weka::ClassBuilder do
         end
       end
 
-      it 'should include them in the defined class' do
+      it 'includes them in the defined class' do
         built_class = subject.build_class(class_name)
         expect(built_class.public_method_defined?(:shared_method)).to be true
       end
@@ -102,7 +102,7 @@ describe Weka::ClassBuilder do
           .and_return(subject.module_eval("class #{class_name}; end"))
       end
 
-      it 'should not include extra methods in the defined class' do
+      it 'does not include extra methods in the defined class' do
         built_class = subject.build_class(class_name)
         expect(built_class.public_method_defined?(:shared_method)).to be false
       end
@@ -111,7 +111,7 @@ describe Weka::ClassBuilder do
     context 'with a defined Weka module' do
       let(:weka_module) { 'explicitly.defined.module' }
 
-      it 'should import the given classes from the defined module' do
+      it 'imports the given classes from the defined module' do
         class_path = "#{weka_module}.#{class_name}"
 
         expect(subject).to receive(:java_import).once.with(class_path)
@@ -122,7 +122,7 @@ describe Weka::ClassBuilder do
 
   describe '.build_classes' do
     context 'without a given weka_module' do
-      it 'should run .build_class for each of the given classes' do
+      it 'runs .build_class for each of the given classes' do
         class_names = %i(SomeClass SomeOtherClass)
 
         expect(subject).to receive(:build_class).exactly(class_names.count).times
@@ -131,7 +131,7 @@ describe Weka::ClassBuilder do
     end
 
     context 'with a given weka_module' do
-      it 'should run .build_class for each of the given classes' do
+      it 'runs .build_class for each of the given classes' do
         class_names = %i(SomeClass SomeOtherClass)
 
         expect(subject).to receive(:build_class).exactly(class_names.count).times

--- a/spec/classifiers/bayes_spec.rb
+++ b/spec/classifiers/bayes_spec.rb
@@ -11,7 +11,7 @@ describe Weka::Classifiers::Bayes do
     :NaiveBayesMultinomialUpdateable,
     :NaiveBayesUpdateable
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/classifiers/bayes_spec.rb
+++ b/spec/classifiers/bayes_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Bayes do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/classifiers/evaluation_spec.rb
+++ b/spec/classifiers/evaluation_spec.rb
@@ -29,7 +29,7 @@ describe Weka::Classifiers::Evaluation do
       weighted_f_measure:             :weighted_fmeasure,
       cumulative_margin_distribution: :toCumulativeMarginDistributionString
     }.each do |alias_method, method|
-      it "should define the alias ##{alias_method} for ##{method}" do
+      it "defines the alias ##{alias_method} for ##{method}" do
         expect(subject.method(method)).to eq subject.method(alias_method)
       end
     end

--- a/spec/classifiers/evaluation_spec.rb
+++ b/spec/classifiers/evaluation_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Evaluation do
-
   subject do
     instances = load_instances('weather.arff')
     instances.class_attribute = :play
@@ -28,7 +27,7 @@ describe Weka::Classifiers::Evaluation do
       unclassified_count:             :unclassified,
       unclassified_percentage:        :pct_unclassified,
       weighted_f_measure:             :weighted_fmeasure,
-      cumulative_margin_distribution: :toCumulativeMarginDistributionString,
+      cumulative_margin_distribution: :toCumulativeMarginDistributionString
     }.each do |alias_method, method|
       it "should define the alias ##{alias_method} for ##{method}" do
         expect(subject.method(method)).to eq subject.method(alias_method)

--- a/spec/classifiers/functions_spec.rb
+++ b/spec/classifiers/functions_spec.rb
@@ -16,7 +16,7 @@ describe Weka::Classifiers::Functions do
     :SMOreg,
     :VotedPerceptron
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/classifiers/functions_spec.rb
+++ b/spec/classifiers/functions_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Functions do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/classifiers/lazy_spec.rb
+++ b/spec/classifiers/lazy_spec.rb
@@ -8,7 +8,7 @@ describe Weka::Classifiers::Lazy do
     :KStar,
     :LWL
   ].each do |class_name|
-    it "should defines a class #{class_name}" do
+    it "definess a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/classifiers/lazy_spec.rb
+++ b/spec/classifiers/lazy_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Lazy do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/classifiers/meta_spec.rb
+++ b/spec/classifiers/meta_spec.rb
@@ -24,7 +24,7 @@ describe Weka::Classifiers::Meta do
     :Stacking,
     :Vote
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/classifiers/meta_spec.rb
+++ b/spec/classifiers/meta_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Meta do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/classifiers/rules_spec.rb
+++ b/spec/classifiers/rules_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Rules do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/classifiers/rules_spec.rb
+++ b/spec/classifiers/rules_spec.rb
@@ -11,7 +11,7 @@ describe Weka::Classifiers::Rules do
     :PART,
     :ZeroR
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/classifiers/trees_spec.rb
+++ b/spec/classifiers/trees_spec.rb
@@ -13,7 +13,7 @@ describe Weka::Classifiers::Trees do
     :RandomTree,
     :REPTree
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/classifiers/trees_spec.rb
+++ b/spec/classifiers/trees_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Trees do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/classifiers/utils_spec.rb
+++ b/spec/classifiers/utils_spec.rb
@@ -35,24 +35,24 @@ describe Weka::Classifiers::Utils do
   it { is_expected.to respond_to :classify }
 
   describe '#train_with_instances' do
-    it 'should call Java‘s #build_classifier' do
+    it 'calls Java’s #build_classifier' do
       expect(subject).to receive(:build_classifier).once.with(instances)
       subject.train_with_instances(instances)
     end
 
-    it 'should set the training_instances' do
+    it 'sets the training_instances' do
       subject = including_class.new
       expect(subject.training_instances).to be_nil
       subject.train_with_instances(instances)
       expect(subject.training_instances).to eq instances
     end
 
-    it 'should return itself' do
+    it 'returns itself' do
       expect(subject.train_with_instances(instances)).to be subject
     end
 
     context 'without an assigned class attribute on instances' do
-      it 'should raise an UnassignedClassError' do
+      it 'raises an UnassignedClassError' do
         instances = load_instances('weather.arff')
 
         expect { including_class.new.train_with_instances(instances) }
@@ -69,18 +69,18 @@ describe Weka::Classifiers::Utils do
       subject.train_with_instances(instances)
     end
 
-    it 'should call Java‘s #update_classifier' do
+    it 'calls Java’s #update_classifier' do
       expect(subject).to receive(:update_classifier).once.with(instance)
       subject.add_training_instance(instance)
     end
 
-    it 'should add the instance to training_instances' do
+    it 'adds the instance to training_instances' do
       expect { subject.add_training_instance(instance) }
         .to change { subject.training_instances.count }
         .by(1)
     end
 
-    it 'should return itself' do
+    it 'returns itself' do
       expect(subject.add_training_instance(instance)).to be_a subject.class
     end
   end
@@ -93,7 +93,7 @@ describe Weka::Classifiers::Utils do
       subject.train_with_instances(instances)
     end
 
-    it 'should call #add_training_instance' do
+    it 'calls #add_training_instance' do
       expect(subject)
         .to receive(:add_training_instance).once
         .with(an_instance_of(Weka::Core::DenseInstance))
@@ -101,7 +101,7 @@ describe Weka::Classifiers::Utils do
       subject.add_training_data(values)
     end
 
-    it 'should return itself' do
+    it 'returns itself' do
       expect(subject.add_training_data(values)).to be_kind_of subject.class
     end
   end
@@ -115,19 +115,19 @@ describe Weka::Classifiers::Utils do
         .to receive(:cross_validate_model)
     end
 
-    it 'should return a Weka::Classifiers::Evaluation' do
+    it 'returns a Weka::Classifiers::Evaluation' do
       return_value = subject.cross_validate
       expect(return_value).to be_kind_of Weka::Classifiers::Evaluation
     end
 
-    it 'should run Java‘s #cross_validate_model on an Evaluation' do
+    it 'runs Java’s #cross_validate_model on an Evaluation' do
       expect_any_instance_of(Weka::Classifiers::Evaluation)
         .to receive(:cross_validate_model).once
 
       subject.cross_validate
     end
 
-    it 'should use 3 folds and the training instances as default test instances' do
+    it 'uses 3 folds and the training instances as default test instances' do
       expect_any_instance_of(Weka::Classifiers::Evaluation)
         .to receive(:cross_validate_model).once
         .with(
@@ -143,7 +143,7 @@ describe Weka::Classifiers::Utils do
     context 'with given folds' do
       let(:folds) { default_folds + 1 }
 
-      it 'should use the given number of folds' do
+      it 'uses the given number of folds' do
         expect_any_instance_of(Weka::Classifiers::Evaluation)
           .to receive(:cross_validate_model).once
           .with(
@@ -156,7 +156,7 @@ describe Weka::Classifiers::Utils do
         subject.cross_validate(folds: folds)
       end
 
-      it 'should use the folds as an integer value' do
+      it 'uses the folds as an integer value' do
         expect_any_instance_of(Weka::Classifiers::Evaluation)
           .to receive(:cross_validate_model).once
           .with(
@@ -173,7 +173,7 @@ describe Weka::Classifiers::Utils do
     context 'without training instances' do
       before { allow(subject).to receive(:training_instances).and_return(nil) }
 
-      it 'should raise an UnassignedTrainingInstancesError' do
+      it 'raises an UnassignedTrainingInstancesError' do
         expect { subject.cross_validate }
           .to raise_error Weka::UnassignedTrainingInstancesError
       end
@@ -186,12 +186,12 @@ describe Weka::Classifiers::Utils do
       allow_any_instance_of(Weka::Classifiers::Evaluation).to receive(:evaluate_model)
     end
 
-    it 'should return a Weka::Classifiers::Evaluation' do
+    it 'returns a Weka::Classifiers::Evaluation' do
       return_value = subject.evaluate(instances)
       expect(return_value).to be_kind_of Weka::Classifiers::Evaluation
     end
 
-    it 'should run Java‘s #evaluate_model on an Evaluation' do
+    it 'runs Java’s #evaluate_model on an Evaluation' do
       expect_any_instance_of(Weka::Classifiers::Evaluation)
         .to receive(:evaluate_model).once
         .with(subject, instances)
@@ -200,7 +200,7 @@ describe Weka::Classifiers::Utils do
     end
 
     context 'without an assigned class attribute on test instances' do
-      it 'should raise an UnassignedClassError' do
+      it 'raises an UnassignedClassError' do
         instances = load_instances('weather.arff')
 
         expect { subject.evaluate(instances) }
@@ -211,7 +211,7 @@ describe Weka::Classifiers::Utils do
     context 'without training instances' do
       before { allow(subject).to receive(:training_instances).and_return(nil) }
 
-      it 'should raise an UnassignedTrainingInstancesError' do
+      it 'raises an UnassignedTrainingInstancesError' do
         expect { subject.evaluate(instances) }
           .to raise_error Weka::UnassignedTrainingInstancesError
       end
@@ -229,7 +229,7 @@ describe Weka::Classifiers::Utils do
     end
 
     context 'with a given instance' do
-      it 'should call Java‘s #classify_instance' do
+      it 'calls Java’s #classify_instance' do
         expect(subject)
           .to receive(:classify_instance).once
           .with(an_instance_of(instance.class))
@@ -237,13 +237,13 @@ describe Weka::Classifiers::Utils do
         subject.classify(instance)
       end
 
-      it 'should return the predicted class value of the instance' do
+      it 'returns the predicted class value of the instance' do
         expect(subject.classify(instance)).to eq class_value
       end
     end
 
     context 'with a given array of values' do
-      it 'should call Java‘s #classify_instance' do
+      it 'calls Java’s #classify_instance' do
         expect(subject)
           .to receive(:classify_instance).once
           .with(an_instance_of(Weka::Core::DenseInstance))
@@ -251,7 +251,7 @@ describe Weka::Classifiers::Utils do
         subject.classify(values)
       end
 
-      it 'should return the predicted class value of the instance' do
+      it 'returns the predicted class value of the instance' do
         expect(subject.classify(values)).to eq class_value
       end
     end
@@ -259,7 +259,7 @@ describe Weka::Classifiers::Utils do
     context 'without training instances' do
       before { allow(subject).to receive(:training_instances).and_return(nil) }
 
-      it 'should raise an UnassignedTrainingInstancesError' do
+      it 'raises an UnassignedTrainingInstancesError' do
         expect { subject.classify(instance) }
           .to raise_error Weka::UnassignedTrainingInstancesError
       end
@@ -279,7 +279,7 @@ describe Weka::Classifiers::Utils do
     end
 
     context 'with a given instance' do
-      it 'should call Java‘s #distribution_for_instance' do
+      it 'calls Java’s #distribution_for_instance' do
         expect(subject)
           .to receive(:distribution_for_instance).once
           .with(an_instance_of(instance.class))
@@ -287,13 +287,13 @@ describe Weka::Classifiers::Utils do
         subject.distribution_for(instance)
       end
 
-      it 'should return the predicted class distributions of the instance' do
+      it 'returns the predicted class distributions of the instance' do
         expect(subject.distribution_for(instance)).to eq class_distributions
       end
     end
 
     context 'with a given array of values' do
-      it 'should call Java‘s #distribution_for_instance' do
+      it 'calls Java’s #distribution_for_instance' do
         expect(subject)
           .to receive(:distribution_for_instance).once
           .with(an_instance_of(Weka::Core::DenseInstance))
@@ -301,7 +301,7 @@ describe Weka::Classifiers::Utils do
         subject.distribution_for(values)
       end
 
-      it 'should return the predicted class distributions of the instance' do
+      it 'returns the predicted class distributions of the instance' do
         expect(subject.distribution_for(values)).to eq class_distributions
       end
     end
@@ -309,7 +309,7 @@ describe Weka::Classifiers::Utils do
     context 'without training instances' do
       before { allow(subject).to receive(:training_instances).and_return(nil) }
 
-      it 'should raise an UnassignedTrainingInstancesError' do
+      it 'raises an UnassignedTrainingInstancesError' do
         expect { subject.distribution_for(instance) }
           .to raise_error Weka::UnassignedTrainingInstancesError
       end

--- a/spec/classifiers/utils_spec.rb
+++ b/spec/classifiers/utils_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Utils do
-
   let(:including_class) do
     Class.new do
       def build_classifier(instances)
@@ -82,7 +81,7 @@ describe Weka::Classifiers::Utils do
     end
 
     it 'should return itself' do
-      expect(subject.add_training_instance(instance)).to be_kind_of subject.class
+      expect(subject.add_training_instance(instance)).to be_a subject.class
     end
   end
 
@@ -274,7 +273,9 @@ describe Weka::Classifiers::Utils do
     let(:class_distributions) { { 'yes' => distributions[0], 'no' => distributions[1] } }
 
     before do
-      allow(subject).to receive(:distribution_for_instance).and_return(distributions)
+      allow(subject)
+        .to receive(:distribution_for_instance)
+        .and_return(distributions)
     end
 
     context 'with a given instance' do
@@ -314,5 +315,4 @@ describe Weka::Classifiers::Utils do
       end
     end
   end
-
 end

--- a/spec/clusterers/cluster_evaluation_spec.rb
+++ b/spec/clusterers/cluster_evaluation_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Clusterers::ClusterEvaluation do
-
   it { is_expected.to be_kind_of(Java::WekaClusterers::ClusterEvaluation) }
 
   describe 'aliases:' do
@@ -14,5 +13,4 @@ describe Weka::Clusterers::ClusterEvaluation do
       end
     end
   end
-
 end

--- a/spec/clusterers/cluster_evaluation_spec.rb
+++ b/spec/clusterers/cluster_evaluation_spec.rb
@@ -8,7 +8,7 @@ describe Weka::Clusterers::ClusterEvaluation do
       summary:        :cluster_results_to_string,
       clusters_count: :num_clusters
     }.each do |alias_method, method|
-      it "should define the alias ##{alias_method} for ##{method}" do
+      it "defines the alias ##{alias_method} for ##{method}" do
         expect(subject.method(method)).to eq subject.method(alias_method)
       end
     end

--- a/spec/clusterers/utils_spec.rb
+++ b/spec/clusterers/utils_spec.rb
@@ -28,19 +28,19 @@ describe Weka::Clusterers::Utils do
   it { is_expected.to respond_to :evaluate }
 
   describe '#train_with_instances' do
-    it 'should call Java‘s #build_classifier' do
+    it 'calls Java’s #build_classifier' do
       expect(subject).to receive(:build_clusterer).once.with(instances)
       subject.train_with_instances(instances)
     end
 
-    it 'should set the training_instances' do
+    it 'sets the training_instances' do
       subject = including_class.new
       expect(subject.training_instances).to be_nil
       subject.train_with_instances(instances)
       expect(subject.training_instances).to eq instances
     end
 
-    it 'should return itself' do
+    it 'returns itself' do
       expect(subject.train_with_instances(instances)).to be subject
     end
   end
@@ -53,18 +53,18 @@ describe Weka::Clusterers::Utils do
       subject.train_with_instances(instances)
     end
 
-    it 'should call Java‘s #update_classifier' do
+    it 'calls Java’s #update_classifier' do
       expect(subject).to receive(:update_clusterer).once.with(instance)
       subject.add_training_instance(instance)
     end
 
-    it 'should add the instance to training_instances' do
+    it 'adds the instance to training_instances' do
       expect { subject.add_training_instance(instance) }
         .to change { subject.training_instances.count }
         .by(1)
     end
 
-    it 'should return itself' do
+    it 'returns itself' do
       expect(subject.add_training_instance(instance)).to be_a subject.class
     end
   end
@@ -77,7 +77,7 @@ describe Weka::Clusterers::Utils do
       subject.train_with_instances(instances)
     end
 
-    it 'should call #add_training_instance' do
+    it 'calls #add_training_instance' do
       expect(subject)
         .to receive(:add_training_instance).once
         .with(an_instance_of(Weka::Core::DenseInstance))
@@ -85,7 +85,7 @@ describe Weka::Clusterers::Utils do
       subject.add_training_data(values)
     end
 
-    it 'should return itself' do
+    it 'returns itself' do
       expect(subject.add_training_data(values)).to be_a subject.class
     end
   end
@@ -128,19 +128,19 @@ describe Weka::Clusterers::Utils do
 
       it { is_expected.to respond_to :cross_validate }
 
-      it 'should return a Weka::Clusterers::ClusterEvaluation' do
+      it 'returns a Weka::Clusterers::ClusterEvaluation' do
         return_value = subject.cross_validate
         expect(return_value).to eq cross_validation_result
       end
 
-      it 'should run Java‘s #cross_validate_model on a ClusterEvaluation' do
+      it 'runs Java’s #cross_validate_model on a ClusterEvaluation' do
         expect(Weka::Clusterers::ClusterEvaluation)
           .to receive(:cross_validate_model).once
 
         subject.cross_validate
       end
 
-      it 'should use 3 folds and the training instances as default test instances' do
+      it 'uses 3 folds and the training instances as default test instances' do
         expect(Weka::Clusterers::ClusterEvaluation)
           .to receive(:cross_validate_model).once
           .with(
@@ -156,7 +156,7 @@ describe Weka::Clusterers::Utils do
       context 'with given folds' do
         let(:folds) { default_folds + 1 }
 
-        it 'should use the given number of folds' do
+        it 'uses the given number of folds' do
           expect(Weka::Clusterers::ClusterEvaluation)
             .to receive(:cross_validate_model).once
             .with(
@@ -169,7 +169,7 @@ describe Weka::Clusterers::Utils do
           subject.cross_validate(folds: folds)
         end
 
-        it 'should use the folds as an integer value' do
+        it 'uses the folds as an integer value' do
           expect(Weka::Clusterers::ClusterEvaluation)
             .to receive(:cross_validate_model).once
             .with(
@@ -188,7 +188,7 @@ describe Weka::Clusterers::Utils do
           allow(subject).to receive(:training_instances).and_return(nil)
         end
 
-        it 'should raise an UnassignedTrainingInstancesError' do
+        it 'raises an UnassignedTrainingInstancesError' do
           expect { subject.cross_validate }
             .to raise_error Weka::UnassignedTrainingInstancesError
         end
@@ -203,12 +203,12 @@ describe Weka::Clusterers::Utils do
         .to receive(:evaluate_clusterer)
     end
 
-    it 'should return a Weka::Clusterers::ClusterEvaluation' do
+    it 'returns a Weka::Clusterers::ClusterEvaluation' do
       return_value = subject.evaluate(instances)
       expect(return_value).to be_kind_of Weka::Clusterers::ClusterEvaluation
     end
 
-    it 'should run Java‘s #evaluate_model on an Evaluation' do
+    it 'runs Java’s #evaluate_model on an Evaluation' do
       expect_any_instance_of(Weka::Clusterers::ClusterEvaluation)
         .to receive(:evaluate_clusterer).once
         .with(instances)
@@ -219,7 +219,7 @@ describe Weka::Clusterers::Utils do
     context 'without training instances' do
       before { allow(subject).to receive(:training_instances).and_return(nil) }
 
-      it 'should raise an UnassignedTrainingInstancesError' do
+      it 'raises an UnassignedTrainingInstancesError' do
         expect { subject.evaluate(instances) }
           .to raise_error Weka::UnassignedTrainingInstancesError
       end
@@ -236,7 +236,7 @@ describe Weka::Clusterers::Utils do
     end
 
     context 'with a given instance' do
-      it 'should call Java‘s #cluster_instance' do
+      it 'calls Java’s #cluster_instance' do
         expect(subject)
           .to receive(:cluster_instance).once
           .with(an_instance_of(instance.class))
@@ -244,13 +244,13 @@ describe Weka::Clusterers::Utils do
         subject.cluster(instance)
       end
 
-      it 'should return the predicted class value of the instance' do
+      it 'returns the predicted class value of the instance' do
         expect(subject.cluster(instance)).to eq cluster
       end
     end
 
     context 'with a given array of values' do
-      it 'should call Java‘s #cluster_instance' do
+      it 'calls Java’s #cluster_instance' do
         expect(subject)
           .to receive(:cluster_instance).once
           .with(an_instance_of(Weka::Core::DenseInstance))
@@ -258,7 +258,7 @@ describe Weka::Clusterers::Utils do
         subject.cluster(values)
       end
 
-      it 'should return the predicted class value of the instance' do
+      it 'returns the predicted class value of the instance' do
         expect(subject.cluster(values)).to eq cluster
       end
     end
@@ -266,7 +266,7 @@ describe Weka::Clusterers::Utils do
     context 'without training instances' do
       before { allow(subject).to receive(:training_instances).and_return(nil) }
 
-      it 'should raise an UnassignedTrainingInstancesError' do
+      it 'raises an UnassignedTrainingInstancesError' do
         expect { subject.cluster(instance) }
           .to raise_error Weka::UnassignedTrainingInstancesError
       end
@@ -285,7 +285,7 @@ describe Weka::Clusterers::Utils do
     end
 
     context 'with a given instance' do
-      it 'should call Java‘s #distribution_for_instance' do
+      it 'calls Java’s #distribution_for_instance' do
         expect(subject)
           .to receive(:distribution_for_instance).once
           .with(an_instance_of(instance.class))
@@ -293,13 +293,13 @@ describe Weka::Clusterers::Utils do
         subject.distribution_for(instance)
       end
 
-      it 'should return the predicted cluster distributions of the instance' do
+      it 'returns the predicted cluster distributions of the instance' do
         expect(subject.distribution_for(instance)).to eq distributions
       end
     end
 
     context 'with a given array of values' do
-      it 'should call Java‘s #distribution_for_instance' do
+      it 'calls Java’s #distribution_for_instance' do
         expect(subject)
           .to receive(:distribution_for_instance).once
           .with(an_instance_of(Weka::Core::DenseInstance))
@@ -307,7 +307,7 @@ describe Weka::Clusterers::Utils do
         subject.distribution_for(values)
       end
 
-      it 'should return the predicted cluster distributions of the instance' do
+      it 'returns the predicted cluster distributions of the instance' do
         expect(subject.distribution_for(values)).to eq distributions
       end
     end
@@ -315,7 +315,7 @@ describe Weka::Clusterers::Utils do
     context 'without training instances' do
       before { allow(subject).to receive(:training_instances).and_return(nil) }
 
-      it 'should raise an UnassignedTrainingInstancesError' do
+      it 'raises an UnassignedTrainingInstancesError' do
         expect { subject.distribution_for(instance) }
           .to raise_error Weka::UnassignedTrainingInstancesError
       end

--- a/spec/clusterers/utils_spec.rb
+++ b/spec/clusterers/utils_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Clusterers::Utils do
-
   let(:including_class) do
     Class.new do
       def build_clusterer(instances)
@@ -66,10 +65,9 @@ describe Weka::Clusterers::Utils do
     end
 
     it 'should return itself' do
-      expect(subject.add_training_instance(instance)).to be_kind_of subject.class
+      expect(subject.add_training_instance(instance)).to be_a subject.class
     end
   end
-
 
   describe '#add_training_data' do
     let(:values) { [:sunny, 85, 85, :FALSE, :no] }
@@ -88,7 +86,7 @@ describe Weka::Clusterers::Utils do
     end
 
     it 'should return itself' do
-      expect(subject.add_training_data(values)).to be_kind_of subject.class
+      expect(subject.add_training_data(values)).to be_a subject.class
     end
   end
 
@@ -136,7 +134,9 @@ describe Weka::Clusterers::Utils do
       end
 
       it 'should run Java‘s #cross_validate_model on a ClusterEvaluation' do
-        expect(Weka::Clusterers::ClusterEvaluation).to receive(:cross_validate_model).once
+        expect(Weka::Clusterers::ClusterEvaluation)
+          .to receive(:cross_validate_model).once
+
         subject.cross_validate
       end
 
@@ -184,7 +184,9 @@ describe Weka::Clusterers::Utils do
       end
 
       context 'without training instances' do
-        before { allow(subject).to receive(:training_instances).and_return(nil) }
+        before do
+          allow(subject).to receive(:training_instances).and_return(nil)
+        end
 
         it 'should raise an UnassignedTrainingInstancesError' do
           expect { subject.cross_validate }
@@ -197,7 +199,8 @@ describe Weka::Clusterers::Utils do
   describe '#evaluate' do
     before do
       allow(subject).to receive(:training_instances).and_return(instances)
-      allow_any_instance_of(Weka::Clusterers::ClusterEvaluation).to receive(:evaluate_clusterer)
+      allow_any_instance_of(Weka::Clusterers::ClusterEvaluation)
+        .to receive(:evaluate_clusterer)
     end
 
     it 'should return a Weka::Clusterers::ClusterEvaluation' do
@@ -224,9 +227,9 @@ describe Weka::Clusterers::Utils do
   end
 
   describe '#cluster' do
-    let(:instance)  { instances.first }
-    let(:values)    { [:overcast, 83, 86, :FALSE, :yes] }
-    let(:cluster)   { 1 }
+    let(:instance) { instances.first }
+    let(:values)   { [:overcast, 83, 86, :FALSE, :yes] }
+    let(:cluster)  { 1 }
 
     before do
       allow(subject).to receive(:cluster_instance).and_return(cluster)
@@ -271,12 +274,14 @@ describe Weka::Clusterers::Utils do
   end
 
   describe '#distribution_for' do
-    let(:instance)            { instances.first }
-    let(:values)              { [:overcast, 83, 86, :FALSE, :yes] }
-    let(:distributions)       { [0.543684388757196, 0.4563156112428039] }
+    let(:instance)      { instances.first }
+    let(:values)        { [:overcast, 83, 86, :FALSE, :yes] }
+    let(:distributions) { [0.543684388757196, 0.4563156112428039] }
 
     before do
-      allow(subject).to receive(:distribution_for_instance).and_return(distributions)
+      allow(subject)
+        .to receive(:distribution_for_instance)
+        .and_return(distributions)
     end
 
     context 'with a given instance' do
@@ -316,5 +321,4 @@ describe Weka::Clusterers::Utils do
       end
     end
   end
-
 end

--- a/spec/clusterers_spec.rb
+++ b/spec/clusterers_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Clusterers do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/clusterers_spec.rb
+++ b/spec/clusterers_spec.rb
@@ -11,7 +11,7 @@ describe Weka::Clusterers do
     :HierarchicalClusterer,
     :SimpleKMeans
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/concerns/buildable_spec.rb
+++ b/spec/concerns/buildable_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Concerns::Buildable do
-
   subject do
     Class.new { include Weka::Concerns::Buildable }
   end
@@ -21,7 +20,7 @@ describe Weka::Concerns::Buildable do
         subject.build { a_public_method }
       end
 
-      it "should return an instance of the including class" do
+      it 'should return an instance of the including class' do
         instance = subject.build { a_public_method }
         expect(instance).to be_kind_of subject
       end

--- a/spec/concerns/buildable_spec.rb
+++ b/spec/concerns/buildable_spec.rb
@@ -5,7 +5,7 @@ describe Weka::Concerns::Buildable do
     Class.new { include Weka::Concerns::Buildable }
   end
 
-  it 'should respond to .build' do
+  it 'responds to .build' do
     expect(subject).to respond_to :build
   end
 
@@ -15,19 +15,19 @@ describe Weka::Concerns::Buildable do
         allow_any_instance_of(subject).to receive(:a_public_method)
       end
 
-      it 'should evaluate the given block on a new class instance' do
+      it 'evaluates the given block on a new class instance' do
         expect_any_instance_of(subject).to receive(:a_public_method).once
         subject.build { a_public_method }
       end
 
-      it 'should return an instance of the including class' do
+      it 'returns an instance of the including class' do
         instance = subject.build { a_public_method }
         expect(instance).to be_kind_of subject
       end
     end
 
     context 'called without a block' do
-      it 'should return an instance of the including class' do
+      it 'returns an instance of the including class' do
         expect(subject.build).to be_kind_of subject
       end
     end

--- a/spec/concerns/describable_spec.rb
+++ b/spec/concerns/describable_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Concerns::Describable do
-
   subject do
     Class.new { include Weka::Concerns::Describable }
   end
@@ -31,7 +30,7 @@ describe Weka::Concerns::Describable do
     end
 
     it 'should return a string' do
-      expect(subject.options).to be_kind_of String
+      expect(subject.options).to be_a String
     end
   end
 end

--- a/spec/concerns/describable_spec.rb
+++ b/spec/concerns/describable_spec.rb
@@ -13,7 +13,7 @@ describe Weka::Concerns::Describable do
       allow_any_instance_of(subject).to receive(:global_info).and_return('')
     end
 
-    it 'should call Weka’s #global_info on a new instance' do
+    it 'calls Weka’s #global_info on a new instance' do
       expect_any_instance_of(subject).to receive(:global_info).once
       subject.description
     end
@@ -24,12 +24,12 @@ describe Weka::Concerns::Describable do
       allow_any_instance_of(subject).to receive(:list_options).and_return([])
     end
 
-    it 'should call Weka’s #list_options on a new instance' do
+    it 'calls Weka’s #list_options on a new instance' do
       expect_any_instance_of(subject).to receive(:list_options).once
       subject.options
     end
 
-    it 'should return a string' do
+    it 'returns a string' do
       expect(subject.options).to be_a String
     end
   end

--- a/spec/concerns/optionizable_spec.rb
+++ b/spec/concerns/optionizable_spec.rb
@@ -8,7 +8,7 @@ describe Weka::Concerns::Optionizable do
   it { is_expected.to respond_to :use_options }
   it { is_expected.to respond_to :options }
 
-  it 'should respond to .default_options' do
+  it 'responds to .default_options' do
     expect(subject.class).to respond_to :default_options
   end
 
@@ -21,7 +21,7 @@ describe Weka::Concerns::Optionizable do
     end
 
     context 'when called with hash options' do
-      it 'should set the given options' do
+      it 'sets the given options' do
         expect(Java::WekaCore::Utils)
           .to receive(:split_options).once
           .with('-I 100 -K 0')
@@ -32,7 +32,7 @@ describe Weka::Concerns::Optionizable do
     end
 
     context 'when called with single options' do
-      it 'should set the given options' do
+      it 'sets the given options' do
         expect(Java::WekaCore::Utils)
           .to receive(:split_options).once
           .with('-O -B')
@@ -43,7 +43,7 @@ describe Weka::Concerns::Optionizable do
     end
 
     context 'when called with single options & hash options' do
-      it 'should set the given options' do
+      it 'sets the given options' do
         expect(Java::WekaCore::Utils)
           .to receive(:split_options).once
           .with('-O -I 100')
@@ -54,7 +54,7 @@ describe Weka::Concerns::Optionizable do
     end
 
     context 'when called with a string' do
-      it 'should set the given options' do
+      it 'sets the given options' do
         expect(Java::WekaCore::Utils)
           .to receive(:split_options).once
           .with('-O -I 100')
@@ -71,7 +71,7 @@ describe Weka::Concerns::Optionizable do
     context 'if both single options & hash option are defined' do
       before { subject.use_options(:O, :B, I: 100) }
 
-      it 'should return the defined options' do
+      it 'returns the defined options' do
         expect(subject.options).to eq '-O -B -I 100'
       end
     end
@@ -79,7 +79,7 @@ describe Weka::Concerns::Optionizable do
     context 'if only single options are defined' do
       before { subject.use_options(:O, :B) }
 
-      it 'should not include an empty hash' do
+      it 'does not include an empty hash' do
         expect(subject.options).to eq '-O -B'
       end
     end
@@ -93,7 +93,7 @@ describe Weka::Concerns::Optionizable do
           .and_return(default_options)
       end
 
-      it 'should return the default options' do
+      it 'returns the default options' do
         expect(subject.options).to eq default_options
       end
     end
@@ -106,12 +106,12 @@ describe Weka::Concerns::Optionizable do
         .and_return(%w(-C last -Z -P 10 -M -B 0.1))
     end
 
-    it 'should receive Java‘s #get_options' do
+    it 'receives Java’s #get_options' do
       expect_any_instance_of(subject.class).to receive(:get_options).once
       subject.class.default_options
     end
 
-    it 'should return a string with the default options' do
+    it 'returns a string with the default options' do
       options = '-C last -Z -P 10 -M -B 0.1'
       expect(subject.class.default_options).to eq options
     end

--- a/spec/concerns/optionizable_spec.rb
+++ b/spec/concerns/optionizable_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Concerns::Optionizable do
-
   subject do
     Class.new { include Weka::Concerns::Optionizable }.new
   end
@@ -104,7 +103,7 @@ describe Weka::Concerns::Optionizable do
     before do
       allow_any_instance_of(subject.class)
         .to receive(:get_options)
-        .and_return(['-C', 'last', '-Z',  '-P', '10', '-M', '-B', '0.1'])
+        .and_return(%w(-C last -Z -P 10 -M -B 0.1))
     end
 
     it 'should receive Java‘s #get_options' do

--- a/spec/concerns/persistent_spec.rb
+++ b/spec/concerns/persistent_spec.rb
@@ -4,7 +4,7 @@ describe Weka::Concerns::Persistent do
   describe 'if included' do
     subject { Class.new }
 
-    it 'should set __persistent__ to true' do
+    it 'sets __persistent__ to true' do
       expect(subject).to receive(:__persistent__=).with(true).once
       subject.include(Weka::Concerns::Persistent)
     end

--- a/spec/concerns/persistent_spec.rb
+++ b/spec/concerns/persistent_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Concerns::Persistent do
-
   describe 'if included' do
     subject { Class.new }
 

--- a/spec/concerns/serializable_spec.rb
+++ b/spec/concerns/serializable_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Concerns::Serializable do
-
   subject do
     Class.new { include Weka::Concerns::Serializable }
   end

--- a/spec/concerns/serializable_spec.rb
+++ b/spec/concerns/serializable_spec.rb
@@ -7,12 +7,12 @@ describe Weka::Concerns::Serializable do
 
   let(:filename) { 'file.model' }
 
-  it 'should respond to #serialize' do
+  it 'responds to #serialize' do
     expect(subject.new).to respond_to :serialize
   end
 
   describe '#serialize' do
-    it 'should call Weka::Core::SerializationHelper.write' do
+    it 'calls Weka::Core::SerializationHelper.write' do
       expect(Weka::Core::SerializationHelper)
         .to receive(:write)
         .with(filename, subject)

--- a/spec/core/attribute_spec.rb
+++ b/spec/core/attribute_spec.rb
@@ -8,7 +8,7 @@ describe Weka::Core::Attribute do
   it { is_expected.to respond_to :internal_value_of }
 
   describe '#values' do
-    it 'should return an array of the values' do
+    it 'returns an array of the values' do
       expect(subject.values).to eq values
     end
   end
@@ -17,23 +17,23 @@ describe Weka::Core::Attribute do
     context 'a numeric attribute' do
       let(:attribute) { Weka::Core::Attribute.new('numeric attribute') }
 
-      it 'should return the value as a float' do
+      it 'returns the value as a float' do
         expect(attribute.internal_value_of(3.5)).to eq 3.5
       end
 
-      it 'should return the value as a float if given as string' do
+      it 'returns the value as a float if given as string' do
         expect(attribute.internal_value_of('3.5')).to eq 3.5
       end
 
-      it 'should return NaN if the given value is Float::NAN' do
+      it 'returns NaN if the given value is Float::NAN' do
         expect(attribute.internal_value_of(Float::NAN)).to be Float::NAN
       end
 
-      it 'should return NaN if the given value is nil' do
+      it 'returns NaN if the given value is nil' do
         expect(attribute.internal_value_of(nil)).to be Float::NAN
       end
 
-      it 'should return NaN if the given value is "?"' do
+      it 'returns NaN if the given value is "?"' do
         expect(attribute.internal_value_of('?')).to be Float::NAN
       end
     end
@@ -41,12 +41,12 @@ describe Weka::Core::Attribute do
     context 'a nominal attribute' do
       let(:attribute) { Weka::Core::Attribute.new('class', %w(true false)) }
 
-      it 'should return the correct internal index' do
+      it 'returns the correct internal index' do
         expect(attribute.internal_value_of('true')).to  eq 0
         expect(attribute.internal_value_of('false')).to eq 1
       end
 
-      it 'should return the correct internal index as given as a non-String' do
+      it 'returns the correct internal index as given as a non-String' do
         expect(attribute.internal_value_of(true)).to eq 0
         expect(attribute.internal_value_of(false)).to eq 1
 
@@ -54,15 +54,15 @@ describe Weka::Core::Attribute do
         expect(attribute.internal_value_of(:false)).to eq 1
       end
 
-      it 'should return NaN if the given value is Float::NAN' do
+      it 'returns NaN if the given value is Float::NAN' do
         expect(attribute.internal_value_of(Float::NAN)).to be Float::NAN
       end
 
-      it 'should return NaN if the given value is nil' do
+      it 'returns NaN if the given value is nil' do
         expect(attribute.internal_value_of(nil)).to be Float::NAN
       end
 
-      it 'should return NaN if the given value is "?"' do
+      it 'returns NaN if the given value is "?"' do
         expect(attribute.internal_value_of('?')).to be Float::NAN
       end
     end
@@ -79,19 +79,19 @@ describe Weka::Core::Attribute do
           .and_return(unix_timestamp)
       end
 
-      it 'should return the right date timestamp value' do
+      it 'returns the right date timestamp value' do
         expect(attribute.internal_value_of(datetime)).to eq unix_timestamp
       end
 
-      it 'should return NaN if the given value is Float::NAN' do
+      it 'returns NaN if the given value is Float::NAN' do
         expect(attribute.internal_value_of(Float::NAN)).to be Float::NAN
       end
 
-      it 'should return NaN if the given value is nil' do
+      it 'returns NaN if the given value is nil' do
         expect(attribute.internal_value_of(nil)).to be Float::NAN
       end
 
-      it 'should return NaN if the given value is "?"' do
+      it 'returns NaN if the given value is "?"' do
         expect(attribute.internal_value_of('?')).to be Float::NAN
       end
     end

--- a/spec/core/attribute_spec.rb
+++ b/spec/core/attribute_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe Weka::Core::Attribute do
-
-  let(:values) { ['yes', 'no'] }
+  let(:values) { %w(yes no) }
   subject { Weka::Core::Attribute.new('class', values) }
 
   it { is_expected.to respond_to :values }
@@ -19,7 +18,7 @@ describe Weka::Core::Attribute do
       let(:attribute) { Weka::Core::Attribute.new('numeric attribute') }
 
       it 'should return the value as a float' do
-        expect(attribute.internal_value_of(3.5)).to   eq 3.5
+        expect(attribute.internal_value_of(3.5)).to eq 3.5
       end
 
       it 'should return the value as a float if given as string' do
@@ -35,12 +34,12 @@ describe Weka::Core::Attribute do
       end
 
       it 'should return NaN if the given value is "?"' do
-        expect(attribute.internal_value_of("?")).to be Float::NAN
+        expect(attribute.internal_value_of('?')).to be Float::NAN
       end
     end
 
     context 'a nominal attribute' do
-      let(:attribute) { Weka::Core::Attribute.new('class', ['true', 'false']) }
+      let(:attribute) { Weka::Core::Attribute.new('class', %w(true false)) }
 
       it 'should return the correct internal index' do
         expect(attribute.internal_value_of('true')).to  eq 0
@@ -64,14 +63,14 @@ describe Weka::Core::Attribute do
       end
 
       it 'should return NaN if the given value is "?"' do
-        expect(attribute.internal_value_of("?")).to be Float::NAN
+        expect(attribute.internal_value_of('?')).to be Float::NAN
       end
     end
 
     context 'a data attribute' do
       let(:attribute)      { Weka::Core::Attribute.new('date', 'yyyy-MM-dd HH:mm') }
       let(:datetime)       { '2015-12-24 11:11' }
-      let(:unix_timestamp) { 1450955460000.0 }
+      let(:unix_timestamp) { 1_450_955_460_000.0 }
 
       before do
         allow(attribute)
@@ -93,7 +92,7 @@ describe Weka::Core::Attribute do
       end
 
       it 'should return NaN if the given value is "?"' do
-        expect(attribute.internal_value_of("?")).to be Float::NAN
+        expect(attribute.internal_value_of('?')).to be Float::NAN
       end
     end
   end

--- a/spec/core/converters_spec.rb
+++ b/spec/core/converters_spec.rb
@@ -11,7 +11,7 @@ describe Weka::Core::Converters do
     :JSONLoader,
     :JSONSaver
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/core/converters_spec.rb
+++ b/spec/core/converters_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Core::Converters do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/core/dense_instance_spec.rb
+++ b/spec/core/dense_instance_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe Weka::Core::DenseInstance do
-
   subject do
     instances = load_instances('weather.arff')
     instances.add_date_attribute('recorded_at')
-    instances.add_instance(['rainy',50, 50,'TRUE','no','2015-12-24 11:11'])
+    instances.add_instance(['rainy', 50, 50, 'TRUE', 'no', '2015-12-24 11:11'])
     instances.instances.last
   end
 
@@ -47,7 +46,7 @@ describe Weka::Core::DenseInstance do
   end
 
   describe '#to_a' do
-    let(:values) { ['rainy',50.0, 50.0,'TRUE','no','2015-12-24 11:11'] }
+    let(:values) { ['rainy', 50.0, 50.0, 'TRUE', 'no', '2015-12-24 11:11'] }
 
     it 'should return an Array with the values of the instance' do
       expect(subject.to_a).to eq values
@@ -74,7 +73,7 @@ describe Weka::Core::DenseInstance do
       expect(attributes).to be_an Array
 
       all_kind_of_attribute = attributes.reduce(true) do |result, attribute|
-        result &&= attribute.kind_of?(Java::WekaCore::Attribute)
+        result && attribute.is_a?(Java::WekaCore::Attribute)
       end
 
       expect(all_kind_of_attribute).to be true
@@ -118,5 +117,4 @@ describe Weka::Core::DenseInstance do
       end
     end
   end
-
 end

--- a/spec/core/dense_instance_spec.rb
+++ b/spec/core/dense_instance_spec.rb
@@ -18,7 +18,7 @@ describe Weka::Core::DenseInstance do
       values:       :to_a,
       values_count: :num_values
     }.each do |method, alias_method|
-      it "should define the alias ##{alias_method} for ##{method}" do
+      it "defines the alias ##{alias_method} for ##{method}" do
         expect(subject.method(method)).to eq subject.method(alias_method)
       end
     end
@@ -26,19 +26,19 @@ describe Weka::Core::DenseInstance do
 
   describe 'instantiation' do
     describe 'with an Integer value' do
-      it 'should create a instance with only missing values' do
+      it 'creates a instance with only missing values' do
         values = Weka::Core::DenseInstance.new(2).values
         expect(values).to eq ['?', '?']
       end
     end
 
     describe 'with an array' do
-      it 'should create an instance with the given values' do
+      it 'creates an instance with the given values' do
         values = Weka::Core::DenseInstance.new([1, 2, 3]).values
         expect(values).to eq [1, 2, 3]
       end
 
-      it 'should handle "?" values or nil values' do
+      it 'handles "?" values or nil values' do
         values = Weka::Core::DenseInstance.new([1, '?', nil, 4]).values
         expect(values).to eq [1, '?', '?', 4]
       end
@@ -48,7 +48,7 @@ describe Weka::Core::DenseInstance do
   describe '#to_a' do
     let(:values) { ['rainy', 50.0, 50.0, 'TRUE', 'no', '2015-12-24 11:11'] }
 
-    it 'should return an Array with the values of the instance' do
+    it 'returns an Array with the values of the instance' do
       expect(subject.to_a).to eq values
     end
 
@@ -61,14 +61,14 @@ describe Weka::Core::DenseInstance do
         instances.instances.last
       end
 
-      it 'should return an Array with the values of the instance' do
+      it 'returns an Array with the values of the instance' do
         expect(subject.to_a).to eq values
       end
     end
   end
 
   describe '#attributes' do
-    it 'should return an Array of Attributes' do
+    it 'returns an Array of Attributes' do
       attributes = subject.attributes
       expect(attributes).to be_an Array
 
@@ -84,7 +84,7 @@ describe Weka::Core::DenseInstance do
     before { @result = nil }
 
     describe '#each_attribute' do
-      it 'should run a block on each attribute' do
+      it 'runs a block on each attribute' do
         subject.each_attribute do |attribute|
           @result = attribute.name unless @result
         end
@@ -93,7 +93,7 @@ describe Weka::Core::DenseInstance do
       end
 
       context 'without a given block' do
-        it 'should return a WekaEnumerator' do
+        it 'returns a WekaEnumerator' do
           expect(subject.each_attribute)
             .to be_kind_of(Java::WekaCore::WekaEnumeration)
         end
@@ -101,7 +101,7 @@ describe Weka::Core::DenseInstance do
     end
 
     describe '#each_attribute_with_index' do
-      it 'should run a block on each attribute' do
+      it 'runs a block on each attribute' do
         subject.each_attribute_with_index do |attribute, index|
           @result = "#{attribute.name}, #{index}" if index == 0
         end
@@ -110,7 +110,7 @@ describe Weka::Core::DenseInstance do
       end
 
       context 'without a given block' do
-        it 'should return a WekaEnumerator' do
+        it 'returns a WekaEnumerator' do
           expect(subject.each_attribute_with_index)
             .to be_kind_of(Java::WekaCore::WekaEnumeration)
         end

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'fileutils'
 
 describe Weka::Core::Instances do
-
   subject { load_instances('weather.arff') }
 
   it { is_expected.to respond_to :each }
@@ -35,7 +34,7 @@ describe Weka::Core::Instances do
   it { is_expected.to respond_to :serialize }
 
   describe 'aliases:' do
-    let (:instances) { described_class.new }
+    let(:instances) { described_class.new }
 
     {
       numeric:             :add_numeric_attribute,
@@ -94,7 +93,7 @@ describe Weka::Core::Instances do
       expect(objects).to be_an Array
 
       all_kind_of_instance = objects.reduce(true) do |result, object|
-        result &&= object.kind_of?(Java::WekaCore::DenseInstance)
+        result && object.is_a?(Java::WekaCore::DenseInstance)
       end
 
       expect(all_kind_of_instance).to be true
@@ -107,7 +106,7 @@ describe Weka::Core::Instances do
       expect(objects).to be_an Array
 
       all_kind_of_attribute = objects.reduce(true) do |result, object|
-        result &&= object.kind_of?(Java::WekaCore::Attribute)
+        result && object.is_a?(Java::WekaCore::Attribute)
       end
 
       expect(all_kind_of_attribute).to be true
@@ -116,7 +115,7 @@ describe Weka::Core::Instances do
 
   describe '#attribute_names' do
     it 'should return an Array of the attribute names' do
-      names = %w{ outlook temperature humidity windy play }
+      names = %w(outlook temperature humidity windy play)
       expect(subject.attribute_names).to eq names
     end
   end
@@ -148,13 +147,13 @@ describe Weka::Core::Instances do
 
     describe '#nominal' do
       it 'can be used to add a nominal attribute' do
-        instances.nominal(name, values: ['yes', 'no'])
+        instances.nominal(name, values: %w(yes no))
         expect(instances.attributes.first).to be_nominal
       end
 
       context 'with the class_attribute option' do
         it 'should define the attribute as class attribute' do
-          instances.nominal(name, values: ['yes', 'no'], class_attribute: true)
+          instances.nominal(name, values: %w(yes no), class_attribute: true)
           expect(instances.class_attribute.name).to eq name
         end
       end
@@ -202,7 +201,7 @@ describe Weka::Core::Instances do
 
         it 'should convert the options into strings' do
           instances.nominal(:attribute_name, values: [true, false])
-          expect(instances.attributes.first.values).to eq ['true', 'false']
+          expect(instances.attributes.first.values).to eq %w(true false)
         end
       end
 
@@ -290,7 +289,7 @@ describe Weka::Core::Instances do
       expect {
         instances.add_attributes do
           numeric 'attribute'
-          nominal 'class', values: ['YES', 'NO']
+          nominal 'class', values: %w(YES NO)
         end
       }.to change { instances.attributes.count }.from(0).to(2)
     end
@@ -300,16 +299,16 @@ describe Weka::Core::Instances do
 
       instances.add_attributes do
         numeric 'attribute'
-        nominal 'class', values: ['YES', 'NO']
+        nominal 'class', values: %w(YES NO)
       end
 
-      expect(instances.attributes.map(&:name)).to eq ['attribute', 'class']
+      expect(instances.attributes.map(&:name)).to eq %w(attribute class)
     end
   end
 
   describe '#initialize' do
     it 'should take a relation_name as argument' do
-      name = 'name'
+      name      = 'name'
       instances = Weka::Core::Instances.new(relation_name: name)
 
       expect(instances.relation_name).to eq name
@@ -494,7 +493,10 @@ describe Weka::Core::Instances do
 
       it 'should return the result of .merge_instance' do
         merged = double('instances')
-        allow(Weka::Core::Instances).to receive(:merge_instances).and_return(merged)
+
+        allow(Weka::Core::Instances)
+          .to receive(:merge_instances)
+          .and_return(merged)
 
         expect(instances_a.merge(instances_b)).to eq merged
       end
@@ -514,5 +516,4 @@ describe Weka::Core::Instances do
       end
     end
   end
-
 end

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -45,7 +45,7 @@ describe Weka::Core::Instances do
       instances_count:     :num_instances,
       attributes_count:    :num_attributes
     }.each do |method, alias_method|
-      it "should define the alias ##{alias_method} for ##{method}" do
+      it "defines the alias ##{alias_method} for ##{method}" do
         expect(instances.method(method)).to eq instances.method(alias_method)
       end
     end
@@ -58,7 +58,7 @@ describe Weka::Core::Instances do
       end
 
       describe ".from_#{type}" do
-        it "should call the Weka::Core::Loader#load_#{type}" do
+        it "calls the Weka::Core::Loader#load_#{type}" do
           expect(Weka::Core::Loader)
             .to receive(:"load_#{type}").once
             .with("test.#{type}")
@@ -76,7 +76,7 @@ describe Weka::Core::Instances do
       end
 
       describe "#to_#{type}" do
-        it "should call the Weka::Core::Saver#save_#{type}" do
+        it "calls the Weka::Core::Saver#save_#{type}" do
           expect(Weka::Core::Saver)
             .to receive(:"save_#{type}").once
             .with(file: "test.#{type}", instances: subject)
@@ -88,7 +88,7 @@ describe Weka::Core::Instances do
   end
 
   describe '#instances' do
-    it 'should return an Array of DenseInstance objects' do
+    it 'returns an Array of DenseInstance objects' do
       objects = subject.instances
       expect(objects).to be_an Array
 
@@ -101,7 +101,7 @@ describe Weka::Core::Instances do
   end
 
   describe '#attributes' do
-    it 'should return an Array of Attribute objects' do
+    it 'returns an Array of Attribute objects' do
       objects = subject.attributes
       expect(objects).to be_an Array
 
@@ -114,7 +114,7 @@ describe Weka::Core::Instances do
   end
 
   describe '#attribute_names' do
-    it 'should return an Array of the attribute names' do
+    it 'returns an Array of the attribute names' do
       names = %w(outlook temperature humidity windy play)
       expect(subject.attribute_names).to eq names
     end
@@ -131,7 +131,7 @@ describe Weka::Core::Instances do
       end
 
       context 'with the class_attribute option' do
-        it 'should define the attribute as class attribute' do
+        it 'defines the attribute as class attribute' do
           instances.numeric(name, class_attribute: true)
           expect(instances.class_attribute.name).to eq name
         end
@@ -152,7 +152,7 @@ describe Weka::Core::Instances do
       end
 
       context 'with the class_attribute option' do
-        it 'should define the attribute as class attribute' do
+        it 'defines the attribute as class attribute' do
           instances.nominal(name, values: %w(yes no), class_attribute: true)
           expect(instances.class_attribute.name).to eq name
         end
@@ -166,7 +166,7 @@ describe Weka::Core::Instances do
       end
 
       context 'with the class_attribute option' do
-        it 'should define the attribute as class attribute' do
+        it 'defines the attribute as class attribute' do
           instances.date(name, class_attribute: true)
           expect(instances.class_attribute.name).to eq name
         end
@@ -194,12 +194,12 @@ describe Weka::Core::Instances do
           expect(instances.attributes.first).to be_nominal
         end
 
-        it 'should convert a single option into an Array' do
+        it 'converts a single option into an Array' do
           instances.nominal(:attribute_name, values: 'yes')
           expect(instances.attributes.first.values).to eq ['yes']
         end
 
-        it 'should convert the options into strings' do
+        it 'converts the options into strings' do
           instances.nominal(:attribute_name, values: [true, false])
           expect(instances.attributes.first.values).to eq %w(true false)
         end
@@ -220,7 +220,7 @@ describe Weka::Core::Instances do
       expect(subject.class_attribute.name).to eq 'play'
     end
 
-    it 'should reset the class attribute if it assigns nil' do
+    it 'resets the class attribute if it assigns nil' do
       subject.class_attribute = :play
 
       expect { subject.class_attribute = nil }
@@ -229,7 +229,7 @@ describe Weka::Core::Instances do
         .to(nil)
     end
 
-    it 'should raise an ArgumentError if the given attribute is not defined' do
+    it 'raises an ArgumentError if the given attribute is not defined' do
       expect { subject.class_attribute = :not_existing_attribute }
         .to raise_error(ArgumentError)
     end
@@ -239,19 +239,18 @@ describe Weka::Core::Instances do
     context 'if class attribute is set' do
       before { subject.class_attribute = :play }
 
-      it 'should return the Attribute' do
+      it 'returns the Attribute' do
         expect(subject.class_attribute).to be_kind_of Weka::Core::Attribute
         expect(subject.class_attribute.name).to eq 'play'
       end
     end
 
     context 'if class attribute is not set' do
-      it 'should not raise a Java::WekaCore::UnassignedClassException' do
-        expect { subject.class_attribute }
-          .not_to raise_error Java::WekaCore::UnassignedClassException
+      it 'does not raise a Java::WekaCore::UnassignedClassException' do
+        expect { subject.class_attribute }.not_to raise_error
       end
 
-      it 'should return nil' do
+      it 'returns nil' do
         expect(subject.class_attribute).to be_nil
       end
     end
@@ -261,13 +260,13 @@ describe Weka::Core::Instances do
     context 'if class_attribute is set' do
       before { subject.class_attribute = :outlook }
 
-      it 'should return true' do
+      it 'returns true' do
         expect(subject.class_attribute_defined?).to be true
       end
     end
 
     context 'if class_attribute is not set' do
-      it 'should return false' do
+      it 'returns false' do
         expect(subject.class_attribute_defined?).to be false
       end
     end
@@ -276,14 +275,14 @@ describe Weka::Core::Instances do
   describe '#reset_class_attribute' do
     before { subject.class_attribute = :play }
 
-    it 'should reset the class attribute' do
+    it 'resets the class attribute' do
       expect { subject.reset_class_attribute }
         .to change { subject.class_attribute }.to(nil)
     end
   end
 
   describe '#add_attributes' do
-    it 'should add the numbers of attributes given in the block' do
+    it 'adds the numbers of attributes given in the block' do
       instances = Weka::Core::Instances.new
 
       expect {
@@ -294,7 +293,7 @@ describe Weka::Core::Instances do
       }.to change { instances.attributes.count }.from(0).to(2)
     end
 
-    it 'should add the types of attributes given in the block' do
+    it 'adds the types of attributes given in the block' do
       instances = Weka::Core::Instances.new
 
       instances.add_attributes do
@@ -307,18 +306,18 @@ describe Weka::Core::Instances do
   end
 
   describe '#initialize' do
-    it 'should take a relation_name as argument' do
+    it 'takes a relation_name as argument' do
       name      = 'name'
       instances = Weka::Core::Instances.new(relation_name: name)
 
       expect(instances.relation_name).to eq name
     end
 
-    it 'should have a default relation_name of "Instances"' do
+    it 'has a default relation_name of "Instances"' do
       expect(Weka::Core::Instances.new.relation_name).to eq 'Instances'
     end
 
-    it 'should take attributes as argument' do
+    it 'takes attributes as argument' do
       attributes = subject.attributes
       instances  = Weka::Core::Instances.new(attributes: attributes)
 
@@ -330,7 +329,7 @@ describe Weka::Core::Instances do
     before { @result = nil }
 
     describe '#each' do
-      it 'should run a block on each instance' do
+      it 'runs a block on each instance' do
         subject.each do |instance|
           @result = instance.value(0) unless @result
         end
@@ -339,7 +338,7 @@ describe Weka::Core::Instances do
       end
 
       context 'without a given block' do
-        it 'should return a WekaEnumerator' do
+        it 'returns a WekaEnumerator' do
           expect(subject.each)
             .to be_kind_of(Java::WekaCore::WekaEnumeration)
         end
@@ -347,7 +346,7 @@ describe Weka::Core::Instances do
     end
 
     describe '#each_with_index' do
-      it 'should run a block on each instance' do
+      it 'runs a block on each instance' do
         subject.each_with_index do |instance, index|
           @result = "#{instance.value(0)}, #{index}" if index == 0
         end
@@ -356,7 +355,7 @@ describe Weka::Core::Instances do
       end
 
       context 'without a given block' do
-        it 'should return a WekaEnumerator' do
+        it 'returns a WekaEnumerator' do
           expect(subject.each_with_index)
             .to be_kind_of(Java::WekaCore::WekaEnumeration)
         end
@@ -364,7 +363,7 @@ describe Weka::Core::Instances do
     end
 
     describe '#each_attribute' do
-      it 'should run a block on each attribute' do
+      it 'runs a block on each attribute' do
         subject.each_attribute do |attribute|
           @result = attribute.name unless @result
         end
@@ -373,7 +372,7 @@ describe Weka::Core::Instances do
       end
 
       context 'without a given block' do
-        it 'should return a WekaEnumerator' do
+        it 'returns a WekaEnumerator' do
           expect(subject.each_attribute)
             .to be_kind_of(Java::WekaCore::WekaEnumeration)
         end
@@ -381,7 +380,7 @@ describe Weka::Core::Instances do
     end
 
     describe '#each_attribute_with_index' do
-      it 'should run a block on each attribute' do
+      it 'runs a block on each attribute' do
         subject.each_attribute_with_index do |attribute, index|
           @result = "#{attribute.name}, #{index}" if index == 0
         end
@@ -390,7 +389,7 @@ describe Weka::Core::Instances do
       end
 
       context 'without a given block' do
-        it 'should return a WekaEnumerator' do
+        it 'returns a WekaEnumerator' do
           expect(subject.each_attribute_with_index)
             .to be_kind_of(Java::WekaCore::WekaEnumeration)
         end
@@ -399,27 +398,27 @@ describe Weka::Core::Instances do
   end
 
   describe '#add_instance' do
-    it 'should add an instance from given values to the Instances object' do
+    it 'adds an instance from given values to the Instances object' do
       data = [:sunny, 70, 80, 'TRUE', :yes]
       subject.add_instance(data)
 
       expect(subject.instances.last.to_s).to eq data.join(',')
     end
 
-    it 'should add a given instance to the Instances object' do
+    it 'adds a given instance to the Instances object' do
       data = subject.first
       subject.add_instance(data)
 
       expect(subject.instances.last.to_s).to eq data.to_s
     end
 
-    it 'should add a given instance with only missing values' do
+    it 'adds a given instance with only missing values' do
       data = Weka::Core::DenseInstance.new(subject.size)
       subject.add_instance(data)
       expect(subject.instances.last.to_s).to eq data.to_s
     end
 
-    it 'should add a given instance with partly missing values' do
+    it 'adds a given instance with partly missing values' do
       data = [:sunny, 70, nil, '?', Float::NAN]
       subject.add_instance(data)
 
@@ -432,20 +431,20 @@ describe Weka::Core::Instances do
       [[:sunny, 70, 80, :TRUE, :yes], [:overcast, 80, 85, :FALSE, :yes]]
     end
 
-    it 'should add the data to the Instances object' do
+    it 'adds the data to the Instances object' do
       expect { subject.add_instances(data) }
         .to change { subject.instances_count }
         .by(data.count)
     end
 
-    it 'should call #add_instance internally' do
+    it 'calls #add_instance internally' do
       expect(subject).to receive(:add_instance).exactly(data.count).times
       subject.add_instances(data)
     end
   end
 
   describe '#internal_values_of' do
-    it 'should return the internal values of the given values' do
+    it 'returns the internal values of the given values' do
       values          = [:sunny, 85, 85, :FALSE, :no]
       internal_values = [0, 85.0, 85.0, 1, 1]
 
@@ -457,7 +456,7 @@ describe Weka::Core::Instances do
     let(:filter) { double('filter') }
     before { allow(filter).to receive(:filter).and_return(subject) }
 
-    it 'should call the given filter‘s #filter method' do
+    it 'calls the given filter‘s #filter method' do
       expect(filter).to receive(:filter).once.with(subject)
       subject.apply_filter(filter)
     end
@@ -467,7 +466,7 @@ describe Weka::Core::Instances do
     let(:filter) { double('filter') }
     before { allow(filter).to receive(:filter).and_return(subject) }
 
-    it 'should call the given filters‘ #filter methods' do
+    it 'calls the given filters‘ #filter methods' do
       expect(filter).to receive(:filter).twice.with(subject)
       subject.apply_filters(filter, filter)
     end
@@ -483,7 +482,7 @@ describe Weka::Core::Instances do
     let(:instances_c) { Weka::Core::Instances.new(attributes: [attribute_c]) }
 
     context 'when merging one instances object' do
-      it 'should call .merge_instance of Weka::Core::Instances' do
+      it 'calls .merge_instance of Weka::Core::Instances' do
         expect(Weka::Core::Instances)
           .to receive(:merge_instances)
           .with(instances_a, instances_b)
@@ -491,7 +490,7 @@ describe Weka::Core::Instances do
         instances_a.merge(instances_b)
       end
 
-      it 'should return the result of .merge_instance' do
+      it 'returns the result of .merge_instance' do
         merged = double('instances')
 
         allow(Weka::Core::Instances)
@@ -503,12 +502,12 @@ describe Weka::Core::Instances do
     end
 
     context 'when merging multiple instances' do
-      it 'should call .merge_instances mutliple times' do
+      it 'calls .merge_instances mutliple times' do
         expect(Weka::Core::Instances).to receive(:merge_instances).twice
         instances_a.merge(instances_b, instances_c)
       end
 
-      it 'should return the merged instances' do
+      it 'returns the merged instances' do
         merged            = instances_a.merge(instances_b, instances_c)
         merged_attributes = [attribute_a, attribute_b, attribute_c]
 

--- a/spec/core/loader_spec.rb
+++ b/spec/core/loader_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe Weka::Core::Loader do
-
-  CLASS_METHODS = %i{ load_arff load_csv load_json }
+  CLASS_METHODS = %i(load_arff load_csv load_json).freeze
 
   CLASS_METHODS.each do |method|
     it "responds to .#{method}" do
@@ -14,7 +13,9 @@ describe Weka::Core::Loader do
     method = "load_#{type}"
 
     describe "##{method}" do
-      let(:file) { File.expand_path("../../support/resources/weather.#{type}", __FILE__) }
+      let(:file) do
+        File.expand_path("../../support/resources/weather.#{type}", __FILE__)
+      end
 
       it "returns an Instances object for a given #{type.upcase} file" do
         instances = described_class.send(method, file)
@@ -22,5 +23,4 @@ describe Weka::Core::Loader do
       end
     end
   end
-
 end

--- a/spec/core/saver_spec.rb
+++ b/spec/core/saver_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 
 describe Weka::Core::Saver do
-
   let(:instances) { load_instances('weather.arff') }
 
   before(:all) { @tmp_dir = File.expand_path('../../tmp/', __FILE__) }
   after(:all)  { FileUtils.remove_dir(@tmp_dir, true) }
 
-  CLASS_METHODS = %i{ save_arff save_csv save_json }
+  CLASS_METHODS = %i(save_arff save_csv save_json).freeze
 
   CLASS_METHODS.each do |method|
     it "responds to .#{method}" do
@@ -28,5 +27,4 @@ describe Weka::Core::Saver do
       end
     end
   end
-
 end

--- a/spec/core/serialization_helper_spec.rb
+++ b/spec/core/serialization_helper_spec.rb
@@ -8,7 +8,7 @@ describe Weka::Core::SerializationHelper do
       write: :serialize,
       read:  :deserialize
     }.each do |method, alias_method|
-      it "should define the alias .#{alias_method} for .#{method}" do
+      it "defines the alias .#{alias_method} for .#{method}" do
         expect(Weka::Core::SerializationHelper.public_class_method(method))
           .to eq Weka::Core::SerializationHelper.public_class_method(alias_method)
       end

--- a/spec/core/serialization_helper_spec.rb
+++ b/spec/core/serialization_helper_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Core::SerializationHelper do
-
   it { is_expected.to be_kind_of Java::WekaCore::SerializationHelper }
 
   describe 'aliases:' do

--- a/spec/filters/supervised/attribute_selection_spec.rb
+++ b/spec/filters/supervised/attribute_selection_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Filters::Supervised::Attribute::AttributeSelection do
-
   describe 'aliases:' do
     {
       set_evaluator: :use_evaluator,

--- a/spec/filters/supervised/attribute_selection_spec.rb
+++ b/spec/filters/supervised/attribute_selection_spec.rb
@@ -6,7 +6,7 @@ describe Weka::Filters::Supervised::Attribute::AttributeSelection do
       set_evaluator: :use_evaluator,
       set_search:    :use_search
     }.each do |method, alias_method|
-      it "should define the alias ##{alias_method} for ##{method}" do
+      it "defines the alias ##{alias_method} for ##{method}" do
         expect(subject.method(method)).to eq subject.method(alias_method)
       end
     end

--- a/spec/filters/supervised/attribute_spec.rb
+++ b/spec/filters/supervised/attribute_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Filters::Supervised::Attribute do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/filters/supervised/attribute_spec.rb
+++ b/spec/filters/supervised/attribute_spec.rb
@@ -13,7 +13,7 @@ describe Weka::Filters::Supervised::Attribute do
     :NominalToBinary,
     :PartitionMembership
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/filters/supervised/instance_spec.rb
+++ b/spec/filters/supervised/instance_spec.rb
@@ -9,7 +9,7 @@ describe Weka::Filters::Supervised::Instance do
     :SpreadSubsample,
     :StratifiedRemoveFolds
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/filters/supervised/instance_spec.rb
+++ b/spec/filters/supervised/instance_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Filters::Supervised::Instance do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/filters/unsupervised/attribute_spec.rb
+++ b/spec/filters/unsupervised/attribute_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Filters::Unsupervised::Attribute do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/filters/unsupervised/attribute_spec.rb
+++ b/spec/filters/unsupervised/attribute_spec.rb
@@ -60,7 +60,7 @@ describe Weka::Filters::Unsupervised::Attribute do
     :TimeSeriesTranslate,
     :Transpose
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/filters/unsupervised/instance_spec.rb
+++ b/spec/filters/unsupervised/instance_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Filters::Unsupervised::Instance do
-
   it_behaves_like 'class builder'
 
   [

--- a/spec/filters/unsupervised/instance_spec.rb
+++ b/spec/filters/unsupervised/instance_spec.rb
@@ -18,7 +18,7 @@ describe Weka::Filters::Unsupervised::Instance do
     :SparseToNonSparse,
     :SubsetByExpression
   ].each do |class_name|
-    it "should define a class #{class_name}" do
+    it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
     end
   end

--- a/spec/filters/utils_spec.rb
+++ b/spec/filters/utils_spec.rb
@@ -15,12 +15,12 @@ describe Weka::Filters::Utils do
       allow(Weka::Filters::Filter).to receive(:use_filter).and_return(nil)
     end
 
-    it 'should set the filter input format' do
+    it 'sets the filter input format' do
       expect(subject).to receive(:set_input_format).with(instances)
       subject.filter(instances)
     end
 
-    it 'should apply the including filter' do
+    it 'applies the including filter' do
       expect(Weka::Filters::Filter)
         .to receive(:use_filter)
         .with(instances, subject)

--- a/spec/filters/utils_spec.rb
+++ b/spec/filters/utils_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Weka::Filters::Utils do
-
   subject do
     Class.new { include Weka::Filters::Utils }.new
   end

--- a/spec/support/instances_helpers.rb
+++ b/spec/support/instances_helpers.rb
@@ -1,5 +1,4 @@
 module InstancesHelpers
-
   def load_instances(file_name)
     file = File.expand_path("./../resources/#{file_name}", __FILE__)
     Weka::Core::Loader.send("load_#{File.extname(file_name)[1..-1]}", file)

--- a/spec/support/shared_examples/class_builder.rb
+++ b/spec/support/shared_examples/class_builder.rb
@@ -1,5 +1,4 @@
 shared_examples 'class builder' do
-
   subject { described_class }
 
   it { is_expected.to respond_to :build_class }

--- a/weka.gemspec
+++ b/weka.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Paul Götze']
   spec.email         = ['paul.christoph.goetze@gmail.com']
 
-  spec.summary       = %q{Machine Learning & Data Mining with JRuby.}
-  spec.description   = %q{A JRuby wrapper for the Weka library (http://www.cs.waikato.ac.nz/ml/weka/)}
+  spec.summary       = 'Machine Learning & Data Mining with JRuby.'
+  spec.description   = 'A JRuby wrapper for the Weka library (http://www.cs.waikato.ac.nz/ml/weka/)'
   spec.homepage      = 'https://github.com/paulgoetze/weka-jruby'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
* Clean up code regarding Rubocop’s default recommendations
* Use spec descriptions without `should`
