### PR TITLE
Drop ActiveSupport as a dependency

### DIFF
--- a/lib/weka/class_builder.rb
+++ b/lib/weka/class_builder.rb
@@ -1,11 +1,11 @@
-require 'active_support/concern'
-require 'active_support/core_ext/string'
-require 'active_support/core_ext/module'
+#require 'active_support/core_ext/module'
 require 'weka/concerns'
 
 module Weka
   module ClassBuilder
-    extend ActiveSupport::Concern
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
 
     module ClassMethods
       def build_class(class_name, weka_module: nil, include_concerns: true)
@@ -36,7 +36,11 @@ module Weka
       end
 
       def super_modules
-        toplevel_module? ? name : name.deconstantize
+        toplevel_module? ? name : deconstantize(name)
+      end
+
+      def deconstantize(name)
+        name.split('::')[0...-1].join('::')
       end
 
       def java_including_module
@@ -44,7 +48,11 @@ module Weka
       end
 
       def including_module
-        name.demodulize unless toplevel_module?
+        demodulize(name) unless toplevel_module?
+      end
+
+      def demodulize(name)
+        name.split('::').last
       end
 
       def toplevel_module?
@@ -74,7 +82,11 @@ module Weka
       end
 
       def utils_defined?
-        utils_super_modules.constantize.const_defined?(:Utils)
+        constantize(utils_super_modules).const_defined?(:Utils)
+      end
+
+      def constantize(module_names)
+        Object.module_eval("::#{module_names}")
       end
 
       def utils
@@ -86,7 +98,7 @@ module Weka
       end
 
       def downcase_first_char(string)
-        return if string.blank?
+        return if string.nil? || string.empty?
         string[0].downcase + string[1..-1]
       end
     end

--- a/lib/weka/classifiers/utils.rb
+++ b/lib/weka/classifiers/utils.rb
@@ -6,129 +6,129 @@ require 'weka/core/instances'
 module Weka
   module Classifiers
     module Utils
-      extend ActiveSupport::Concern
+      def self.included(base)
+        base.class_eval do
+          java_import 'java.util.Random'
 
-      included do
-        java_import 'java.util.Random'
+          if instance_methods.include?(:build_classifier)
+            attr_reader :training_instances
 
-        if instance_methods.include?(:build_classifier)
-          attr_reader :training_instances
+            def train_with_instances(instances)
+              ensure_class_attribute_assigned!(instances)
 
-          def train_with_instances(instances)
-            ensure_class_attribute_assigned!(instances)
+              @training_instances = instances
+              build_classifier(instances)
 
-            @training_instances = instances
-            build_classifier(instances)
+              self
+            end
 
-            self
+            def cross_validate(folds: 3)
+              ensure_trained_with_instances!
+
+              evaluation = Evaluation.new(training_instances)
+              random     = Java::JavaUtil::Random.new(1)
+
+              evaluation.cross_validate_model(self, training_instances, folds.to_i, random)
+              evaluation
+            end
+
+            def evaluate(test_instances)
+              ensure_trained_with_instances!
+              ensure_class_attribute_assigned!(test_instances)
+
+              evaluation = Evaluation.new(training_instances)
+              evaluation.evaluate_model(self, test_instances)
+              evaluation
+            end
           end
 
-          def cross_validate(folds: 3)
-            ensure_trained_with_instances!
+          if instance_methods.include?(:classify_instance)
+            def classify(instance_or_values)
+              ensure_trained_with_instances!
 
-            evaluation = Evaluation.new(training_instances)
-            random     = Java::JavaUtil::Random.new(1)
+              instance = classifiable_instance_from(instance_or_values)
+              index    = classify_instance(instance)
 
-            evaluation.cross_validate_model(self, training_instances, folds.to_i, random)
-            evaluation
+              class_value_of_index(index)
+            end
           end
 
-          def evaluate(test_instances)
-            ensure_trained_with_instances!
-            ensure_class_attribute_assigned!(test_instances)
+          if instance_methods.include?(:update_classifier)
+            def add_training_instance(instance)
+              training_instances.add(instance)
+              update_classifier(instance)
 
-            evaluation = Evaluation.new(training_instances)
-            evaluation.evaluate_model(self, test_instances)
-            evaluation
-          end
-        end
+              self
+            end
 
-        if instance_methods.include?(:classify_instance)
-          def classify(instance_or_values)
-            ensure_trained_with_instances!
-
-            instance = classifiable_instance_from(instance_or_values)
-            index    = classify_instance(instance)
-
-            class_value_of_index(index)
-          end
-        end
-
-        if instance_methods.include?(:update_classifier)
-          def add_training_instance(instance)
-            training_instances.add(instance)
-            update_classifier(instance)
-
-            self
+            def add_training_data(data)
+              values   = training_instances.internal_values_of(data)
+              instance = Weka::Core::DenseInstance.new(values)
+              add_training_instance(instance)
+            end
           end
 
-          def add_training_data(data)
-            values   = training_instances.internal_values_of(data)
-            instance = Weka::Core::DenseInstance.new(values)
-            add_training_instance(instance)
+          if instance_methods.include?(:distribution_for_instance)
+            def distribution_for(instance_or_values)
+              ensure_trained_with_instances!
+
+              instance      = classifiable_instance_from(instance_or_values)
+              distributions = distribution_for_instance(instance)
+
+              class_distributions_from(distributions).with_indifferent_access
+            end
           end
-        end
 
-        if instance_methods.include?(:distribution_for_instance)
-          def distribution_for(instance_or_values)
-            ensure_trained_with_instances!
+          private
 
-            instance      = classifiable_instance_from(instance_or_values)
-            distributions = distribution_for_instance(instance)
+          def ensure_class_attribute_assigned!(instances)
+            return if instances.class_attribute_defined?
 
-            class_distributions_from(distributions).with_indifferent_access
+            error   = 'Class attribute is not assigned for Instances.'
+            hint    = 'You can assign a class attribute with #class_attribute=.'
+            message = "#{error} #{hint}"
+
+            raise UnassignedClassError, message
           end
-        end
 
-        private
+          def ensure_trained_with_instances!
+            return unless training_instances.nil?
 
-        def ensure_class_attribute_assigned!(instances)
-          return if instances.class_attribute_defined?
+            error   = 'Classifier is not trained with Instances.'
+            hint    = 'You can set the training instances with #train_with_instances.'
+            message = "#{error} #{hint}"
 
-          error   = 'Class attribute is not assigned for Instances.'
-          hint    = 'You can assign a class attribute with #class_attribute=.'
-          message = "#{error} #{hint}"
+            raise UnassignedTrainingInstancesError, message
+          end
 
-          raise UnassignedClassError, message
-        end
+          def classifiable_instance_from(instance_or_values)
+            attributes = training_instances.attributes
+            instances  = Weka::Core::Instances.new(attributes: attributes)
 
-        def ensure_trained_with_instances!
-          return unless training_instances.nil?
+            class_attribute = training_instances.class_attribute
+            class_index     = training_instances.class_index
+            instances.insert_attribute_at(class_attribute, class_index)
 
-          error   = 'Classifier is not trained with Instances.'
-          hint    = 'You can set the training instances with #train_with_instances.'
-          message = "#{error} #{hint}"
+            instances.class_index = training_instances.class_index
+            instances.add_instance(instance_or_values)
 
-          raise UnassignedTrainingInstancesError, message
-        end
+            instance = instances.first
+            instance.set_class_missing
+            instance
+          end
 
-        def classifiable_instance_from(instance_or_values)
-          attributes = training_instances.attributes
-          instances  = Weka::Core::Instances.new(attributes: attributes)
+          def class_value_of_index(index)
+            training_instances.class_attribute.value(index)
+          end
 
-          class_attribute = training_instances.class_attribute
-          class_index     = training_instances.class_index
-          instances.insert_attribute_at(class_attribute, class_index)
+          def class_distributions_from(distributions)
+            class_values = training_instances.class_attribute.values
 
-          instances.class_index = training_instances.class_index
-          instances.add_instance(instance_or_values)
-
-          instance = instances.first
-          instance.set_class_missing
-          instance
-        end
-
-        def class_value_of_index(index)
-          training_instances.class_attribute.value(index)
-        end
-
-        def class_distributions_from(distributions)
-          class_values = training_instances.class_attribute.values
-
-          distributions.each_with_index.reduce({}) do |result, (distribution, index)|
-            class_value = class_values[index].to_sym
-            result[class_value] = distribution
-            result
+            distributions.each_with_index.reduce({}) do |result, (distribution, index)|
+              class_value = class_values[index].to_sym
+              result[class_value] = distribution
+              result
+            end
           end
         end
       end

--- a/lib/weka/clusterers/utils.rb
+++ b/lib/weka/clusterers/utils.rb
@@ -1,99 +1,98 @@
-require 'active_support/concern'
 require 'weka/clusterers/cluster_evaluation'
 require 'weka/core/instances'
 
 module Weka
   module Clusterers
     module Utils
-      extend ActiveSupport::Concern
+      def self.included(base)
+        base.class_eval do
+          java_import 'java.util.Random'
 
-      included do
-        java_import 'java.util.Random'
+          if instance_methods.include?(:build_clusterer)
+            attr_reader :training_instances
 
-        if instance_methods.include?(:build_clusterer)
-          attr_reader :training_instances
+            def train_with_instances(instances)
+              @training_instances = instances
+              build_clusterer(instances)
 
-          def train_with_instances(instances)
-            @training_instances = instances
-            build_clusterer(instances)
+              self
+            end
 
-            self
-          end
+            if ancestors.include?(Java::WekaClusterers::DensityBasedClusterer)
+              def cross_validate(folds: 3)
+                ensure_trained_with_instances!
 
-          if ancestors.include?(Java::WekaClusterers::DensityBasedClusterer)
-            def cross_validate(folds: 3)
+                ClusterEvaluation.cross_validate_model(
+                  self,
+                  training_instances,
+                  folds.to_i,
+                  Java::JavaUtil::Random.new(1)
+                )
+              end
+            end
+
+            def evaluate(test_instances)
               ensure_trained_with_instances!
 
-              ClusterEvaluation.cross_validate_model(
-                self,
-                training_instances,
-                folds.to_i,
-                Java::JavaUtil::Random.new(1)
-              )
+              ClusterEvaluation.new.tap do |evaluation|
+                evaluation.clusterer = self
+                evaluation.evaluate_clusterer(test_instances)
+              end
             end
           end
 
-          def evaluate(test_instances)
-            ensure_trained_with_instances!
+          if instance_methods.include?(:cluster_instance)
+            def cluster(instance_or_values)
+              ensure_trained_with_instances!
 
-            ClusterEvaluation.new.tap do |evaluation|
-              evaluation.clusterer = self
-              evaluation.evaluate_clusterer(test_instances)
+              instance = clusterable_instance_from(instance_or_values)
+              cluster_instance(instance)
             end
           end
-        end
 
-        if instance_methods.include?(:cluster_instance)
-          def cluster(instance_or_values)
-            ensure_trained_with_instances!
+          if instance_methods.include?(:update_clusterer)
+            def add_training_instance(instance)
+              training_instances.add(instance)
+              update_clusterer(instance)
 
-            instance = clusterable_instance_from(instance_or_values)
-            cluster_instance(instance)
-          end
-        end
+              self
+            end
 
-        if instance_methods.include?(:update_clusterer)
-          def add_training_instance(instance)
-            training_instances.add(instance)
-            update_clusterer(instance)
-
-            self
+            def add_training_data(data)
+              values   = training_instances.internal_values_of(data)
+              instance = Weka::Core::DenseInstance.new(values)
+              add_training_instance(instance)
+            end
           end
 
-          def add_training_data(data)
-            values   = training_instances.internal_values_of(data)
-            instance = Weka::Core::DenseInstance.new(values)
-            add_training_instance(instance)
+          if instance_methods.include?(:distribution_for_instance)
+            def distribution_for(instance_or_values)
+              ensure_trained_with_instances!
+
+              instance = clusterable_instance_from(instance_or_values)
+              distribution_for_instance(instance).to_a
+            end
           end
-        end
 
-        if instance_methods.include?(:distribution_for_instance)
-          def distribution_for(instance_or_values)
-            ensure_trained_with_instances!
+          private
 
-            instance = clusterable_instance_from(instance_or_values)
-            distribution_for_instance(instance).to_a
+          def ensure_trained_with_instances!
+            return unless training_instances.nil?
+
+            error   = 'Clusterer is not trained with Instances.'
+            hint    = 'You can set the training instances with #train_with_instances.'
+            message = "#{error} #{hint}"
+
+            raise UnassignedTrainingInstancesError, message
           end
-        end
 
-        private
+          def clusterable_instance_from(instance_or_values)
+            attributes = training_instances.attributes
+            instances  = Weka::Core::Instances.new(attributes: attributes)
 
-        def ensure_trained_with_instances!
-          return unless training_instances.nil?
-
-          error   = 'Clusterer is not trained with Instances.'
-          hint    = 'You can set the training instances with #train_with_instances.'
-          message = "#{error} #{hint}"
-
-          raise UnassignedTrainingInstancesError, message
-        end
-
-        def clusterable_instance_from(instance_or_values)
-          attributes = training_instances.attributes
-          instances  = Weka::Core::Instances.new(attributes: attributes)
-
-          instances.add_instance(instance_or_values)
-          instances.first
+            instances.add_instance(instance_or_values)
+            instances.first
+          end
         end
       end
     end

--- a/lib/weka/concerns.rb
+++ b/lib/weka/concerns.rb
@@ -1,4 +1,3 @@
-require 'active_support/concern'
 require 'weka/concerns/buildable'
 require 'weka/concerns/describable'
 require 'weka/concerns/optionizable'
@@ -7,13 +6,11 @@ require 'weka/concerns/serializable'
 
 module Weka
   module Concerns
-    extend ActiveSupport::Concern
-
-    included do
-      include Buildable
-      include Describable
-      include Optionizable
-      include Persistent
+    def self.included(base)
+      base.include Buildable
+      base.include Describable
+      base.include Optionizable
+      base.include Persistent
     end
   end
 end

--- a/lib/weka/concerns/buildable.rb
+++ b/lib/weka/concerns/buildable.rb
@@ -1,9 +1,9 @@
-require 'active_support/concern'
-
 module Weka
   module Concerns
     module Buildable
-      extend ActiveSupport::Concern
+      def self.included(base)
+        base.extend ClassMethods
+      end
 
       module ClassMethods
         def build(&block)

--- a/lib/weka/concerns/describable.rb
+++ b/lib/weka/concerns/describable.rb
@@ -1,9 +1,9 @@
-require 'active_support/concern'
-
 module Weka
   module Concerns
     module Describable
-      extend ActiveSupport::Concern
+      def self.included(base)
+        base.extend ClassMethods
+      end
 
       module ClassMethods
         def description

--- a/lib/weka/concerns/optionizable.rb
+++ b/lib/weka/concerns/optionizable.rb
@@ -1,40 +1,40 @@
-require 'active_support/concern'
-
 module Weka
   module Concerns
     module Optionizable
-      extend ActiveSupport::Concern
+      def self.included(base)
+        base.extend(ClassMethods)
 
-      included do
-        java_import 'weka.core.Utils'
+        base.class_eval do
+          java_import 'weka.core.Utils'
 
-        def use_options(*single_options, **hash_options)
-          joined_options = join_options(single_options, hash_options)
-          options        = Java::WekaCore::Utils.split_options(joined_options)
+          def use_options(*single_options, **hash_options)
+            joined_options = join_options(single_options, hash_options)
+            options        = Java::WekaCore::Utils.split_options(joined_options)
 
-          set_options(options)
-          @options = joined_options
-        end
+            set_options(options)
+            @options = joined_options
+          end
 
-        def options
-          @options || self.class.default_options
-        end
+          def options
+            @options || self.class.default_options
+          end
 
-        private
+          private
 
-        def join_options(*single_options, **hash_options)
-          [
-            join_single_options(*single_options),
-            join_hash_options(**hash_options)
-          ].reject(&:empty?).join(' ')
-        end
+          def join_options(*single_options, **hash_options)
+            [
+              join_single_options(*single_options),
+              join_hash_options(**hash_options)
+            ].reject(&:empty?).join(' ')
+          end
 
-        def join_single_options(options)
-          options.map { |option| "-#{option.to_s.sub(/^-/, '')}" }.join(' ')
-        end
+          def join_single_options(options)
+            options.map { |option| "-#{option.to_s.sub(/^-/, '')}" }.join(' ')
+          end
 
-        def join_hash_options(options)
-          options.map { |key, value| "-#{key} #{value}" }.join(' ')
+          def join_hash_options(options)
+            options.map { |key, value| "-#{key} #{value}" }.join(' ')
+          end
         end
       end
 

--- a/lib/weka/concerns/persistent.rb
+++ b/lib/weka/concerns/persistent.rb
@@ -1,12 +1,10 @@
-require 'active_support/concern'
-
 module Weka
   module Concerns
     module Persistent
-      extend ActiveSupport::Concern
-
-      included do
-        self.__persistent__ = true if respond_to?(:__persistent__=)
+      def self.included(base)
+        base.class_eval do
+          self.__persistent__ = true if respond_to?(:__persistent__=)
+        end
       end
     end
   end

--- a/lib/weka/concerns/serializable.rb
+++ b/lib/weka/concerns/serializable.rb
@@ -1,14 +1,13 @@
-require 'active_support/concern'
 require 'weka/core/serialization_helper'
 
 module Weka
   module Concerns
     module Serializable
-      extend ActiveSupport::Concern
-
-      included do
-        def serialize(filename)
-          Weka::Core::SerializationHelper.write(filename, self)
+      def self.included(base)
+        base.class_eval do
+          def serialize(filename)
+            Weka::Core::SerializationHelper.write(filename, self)
+          end
         end
       end
     end

--- a/lib/weka/filters/utils.rb
+++ b/lib/weka/filters/utils.rb
@@ -1,14 +1,12 @@
-require 'active_support/concern'
-
 module Weka
   module Filters
     module Utils
-      extend ActiveSupport::Concern
-
-      included do
-        def filter(instances)
-          set_input_format(instances)
-          Filter.use_filter(instances, self)
+      def self.included(base)
+        base.class_eval do
+          def filter(instances)
+            set_input_format(instances)
+            Filter.use_filter(instances, self)
+          end
         end
       end
     end

--- a/lib/weka/jars.rb
+++ b/lib/weka/jars.rb
@@ -1,18 +1,16 @@
-require 'active_support/concern'
-
 module Weka
   module Jars
-    extend ActiveSupport::Concern
+    def self.included(base)
+      base.class_eval do
+        require 'lock_jar'
 
-    included do
-      require 'lock_jar'
+        lib_path = File.expand_path('../../', File.dirname(__FILE__))
+        lockfile = File.join(lib_path, 'Jarfile.lock')
+        jars_dir = File.join(lib_path, 'jars')
 
-      lib_path = File.expand_path('../../', File.dirname(__FILE__))
-      lockfile = File.join(lib_path, 'Jarfile.lock')
-      jars_dir = File.join(lib_path, 'jars')
-
-      LockJar.install(lockfile, local_repo: jars_dir)
-      LockJar.load(lockfile, local_repo: jars_dir)
+        LockJar.install(lockfile, local_repo: jars_dir)
+        LockJar.load(lockfile, local_repo: jars_dir)
+      end
     end
   end
 end

--- a/weka.gemspec
+++ b/weka.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency     'lock_jar',         '~> 0.13'
-  spec.add_runtime_dependency     'activesupport',    '~> 4.0'
 
   spec.add_development_dependency 'bundler',          '~> 1.6'
   spec.add_development_dependency 'rake',             '~> 10.0'


### PR DESCRIPTION
Since only a fraction of ActiveSupport’s functionality is used (`concerns`, and a couple of String methods, like `#blank`, `#demodulize`, `#(de)constantize`) there is no need to rely on the full dependency.

Now uses plain 

```ruby
def self.included(base)
  base.extend(ClassMethods)
end
```

and 

```ruby
def self.included(base)
  base.class_eval do
    # ...
  end
end
```

instead of ActiveSupport::Concerns and implement the string methods itself.