### PR TITLE
Remove missed ActiveSupport dependencies

### DIFF
--- a/lib/weka/class_builder.rb
+++ b/lib/weka/class_builder.rb
@@ -1,4 +1,3 @@
-#require 'active_support/core_ext/module'
 require 'weka/concerns'
 
 module Weka

--- a/lib/weka/classifiers/utils.rb
+++ b/lib/weka/classifiers/utils.rb
@@ -1,5 +1,3 @@
-require 'active_support/concern'
-require 'active_support/core_ext/hash'
 require 'weka/classifiers/evaluation'
 require 'weka/core/instances'
 
@@ -75,7 +73,7 @@ module Weka
               instance      = classifiable_instance_from(instance_or_values)
               distributions = distribution_for_instance(instance)
 
-              class_distributions_from(distributions).with_indifferent_access
+              class_distributions_from(distributions)
             end
           end
 
@@ -125,7 +123,7 @@ module Weka
             class_values = training_instances.class_attribute.values
 
             distributions.each_with_index.reduce({}) do |result, (distribution, index)|
-              class_value = class_values[index].to_sym
+              class_value = class_values[index]
               result[class_value] = distribution
               result
             end

--- a/spec/attribute_selection/evaluator_spec.rb
+++ b/spec/attribute_selection/evaluator_spec.rb
@@ -20,8 +20,8 @@ describe Weka::AttributeSelection::Evaluator do
     end
 
     it "inherits class #{class_name} from #{super_class_name}" do
-      evaluator_class = "#{subject}::#{class_name}".constantize
-      super_class     = "#{subject}::#{super_class_name}".constantize
+      evaluator_class = Object.module_eval("#{subject}::#{class_name}")
+      super_class     = Object.module_eval("#{subject}::#{super_class_name}")
 
       expect(evaluator_class.new).to be_kind_of super_class
     end


### PR DESCRIPTION
Removes left over ActiveSupport dependencies from #8.

Drops indifferent access to the returned distributions from a classifier’s [`#distribution_for`](https://github.com/paulgoetze/weka-jruby/blob/5dc401d734e7fd6d43eab15e4c7c982dbb485722/lib/weka/classifiers/utils.rb#L72-L79) method. Values can only be accessed by the string key.