### PR TITLE
Feature: allow passing hash to Instances#add_instance

### DIFF
--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -55,7 +55,7 @@ module Weka
 
       def attribute_names(use_symbol = false)
         if use_symbol
-          attributes.map(&:name).map(&:to_sym)
+          attributes.map { |attribute| attribute.name.to_sym }
         else
           attributes.map(&:name)
         end
@@ -195,19 +195,21 @@ module Weka
 
       # Add new instance
       # @param [Instance, Array, Hash] instance_or_values the attribute values
-      #   of the instance to be added
+      #   of the instance to be added. If passing an array, the attribute values
+      #   must be in the same order as the attributes defined in Instances.
+      #   If passing a hash, The keys are the names of the attributes and their
+      #   values are corresponding attributes values.
       #
       # @example Passing Instance
       #   instances.add_instance(instance)
       #
-      # @example Passing an array of attribute values. Note that the attribute
-      #   values must be in the same order as the Instances attributes.
-      #   instances.add_instance([attr1_value, attr2_value, attr3_value, ...])
+      # @example Passing an array of attribute values
+      #   attribute_values = [attr1_value, attr2_value, attr3_value, ...]
+      #   instances.add_instance(attribute_values)
       #
-      # @example Passing a hash of attribute values. The keys are the names of
-      #   the attributes and their values are corresponding attribute values.
-      #   hash = { attr1_name: attr1_value, attr2_name: attr2_value, ... }
-      #   instances.add_instance(hash)
+      # @example Passing a hash of attribute values.
+      #   attribute_values = { attr1_name: attr1_value, attr2_name: attr2_value, ... }
+      #   instances.add_instance(attribute_values)
       #
       def add_instance(instance_or_values, weight: 1.0)
         instance = instance_from(instance_or_values, weight: weight)
@@ -319,7 +321,7 @@ module Weka
         Attribute.const_get(type.upcase)
       end
 
-      # Map a hash whose keys are attribute names and values are attribute
+      # convert a hash whose keys are attribute names and values are attribute
       #   values into an array containing attribute values in the order
       #   of the Instances attributes.
       #
@@ -334,7 +336,7 @@ module Weka
         end
       end
 
-      # Map an array of attribute values in the same order as Instances
+      # convert an array of attribute values in the same order as Instances
       #   attributes into a hash whose keys are attribute names and values
       #   are corresponding attribute values.
       #
@@ -343,12 +345,10 @@ module Weka
       #
       # @return [Hash] a hash as described above
       def attribute_values_to_hash(attribute_values)
-        # TODO: make this pretty
-        hash = {}
-        attribute_names(true).each_with_index do |attribute_name, index|
-          hash[attribute_name] = attribute_values[index]
+        attribute_names(true).each_with_index.inject({}) do |hash, (attr_name, index)|
+          hash[attr_name] = attribute_values[index]
+          hash
         end
-        hash
       end
     end
 

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -298,7 +298,7 @@ module Weka
           end
 
           data = internal_values_of(instance_or_values)
-          check_string_attributes(data, instance_or_values) if has_string_attribute?
+          data = check_string_attributes(data, instance_or_values) if has_string_attribute?
           DenseInstance.new(data, weight: weight)
         end
       end
@@ -341,7 +341,7 @@ module Weka
         # string attribute has unlimited range of possible values.
         # Check the return index, if it is -1 then add the value to
         # the attribute before creating the instance
-        internal_values.map!.with_index do |value, index|
+        internal_values.map.with_index do |value, index|
           if value == -1 && attribute(index).string?
             attribute(index).add_string_value(attribute_values[index])
           else

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -204,12 +204,12 @@ module Weka
       #   instances.add_instance(instance)
       #
       # @example Passing an array of attribute values
-      #   attribute_values = [attr1_value, attr2_value, attr3_value, ...]
-      #   instances.add_instance(attribute_values)
+      #   attr_values = [attr1_value, attr2_value, attr3_value]
+      #   instances.add_instance(attr_values)
       #
       # @example Passing a hash of attribute values.
-      #   attribute_values = { attr1_name: attr1_value, attr2_name: attr2_value, ... }
-      #   instances.add_instance(attribute_values)
+      #   attr_values = { attr1_name: attr1_value, attr2_name: attr2_value }
+      #   instances.add_instance(attr_values)
       #
       def add_instance(instance_or_values, weight: 1.0)
         instance = instance_from(instance_or_values, weight: weight)
@@ -289,29 +289,16 @@ module Weka
       # @return [Instance] the object that contains the given
       #   attribute values.
       def instance_from(instance_or_values, weight:)
-
         if instance_or_values.is_a?(Java::WekaCore::Instance)
           instance_or_values.weight = weight
           instance_or_values
         else
-
           if instance_or_values.is_a?(Hash)
             instance_or_values = attribute_values_from_hash(instance_or_values)
           end
 
           data = internal_values_of(instance_or_values)
-
-          # string attribute has unlimited range of possible values.
-          # Check the return index, if it is -1 then add the value to
-          # the attribute before creating the instance
-          data.map!.with_index do |value, index|
-            if value == -1 && attribute(index).string?
-              attribute(index).add_string_value(instance_or_values[index])
-            else
-              value
-            end
-          end
-
+          data = check_string_attributes(data, instance_or_values)
           DenseInstance.new(data, weight: weight)
         end
       end
@@ -345,9 +332,21 @@ module Weka
       #
       # @return [Hash] a hash as described above
       def attribute_values_to_hash(attribute_values)
-        attribute_names(true).each_with_index.inject({}) do |hash, (attr_name, index)|
+        attribute_names(true).each_with_object({}).with_index do |(attr_name, hash), index|
           hash[attr_name] = attribute_values[index]
-          hash
+        end
+      end
+
+      def check_string_attributes(internal_values, attribute_values)
+        # string attribute has unlimited range of possible values.
+        # Check the return index, if it is -1 then add the value to
+        # the attribute before creating the instance
+        internal_values.map!.with_index do |value, index|
+          if value == -1 && attribute(index).string?
+            attribute(index).add_string_value(attribute_values[index])
+          else
+            value
+          end
         end
       end
     end

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -298,7 +298,7 @@ module Weka
           end
 
           data = internal_values_of(instance_or_values)
-          data = check_string_attributes(data, instance_or_values)
+          check_string_attributes(data, instance_or_values) if has_string_attribute?
           DenseInstance.new(data, weight: weight)
         end
       end

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -308,7 +308,7 @@ module Weka
         Attribute.const_get(type.upcase)
       end
 
-      # convert a hash whose keys are attribute names and values are attribute
+      # Convert a hash whose keys are attribute names and values are attribute
       #   values into an array containing attribute values in the order
       #   of the Instances attributes.
       #
@@ -323,7 +323,7 @@ module Weka
         end
       end
 
-      # convert an array of attribute values in the same order as Instances
+      # Convert an array of attribute values in the same order as Instances
       #   attributes into a hash whose keys are attribute names and values
       #   are corresponding attribute values.
       #

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -318,7 +318,9 @@ module Weka
       # @return [Array] an array containing attribute values in the
       #   correct order
       def attribute_values_from_hash(attribute_values)
-        attribute_names(true).inject([]) do |values, attribute_name|
+        names = attribute_names(true)
+        names << class_attribute.name.to_sym if class_attribute_defined?
+        names.inject([]) do |values, attribute_name|
           values << attribute_values[attribute_name]
         end
       end
@@ -332,7 +334,9 @@ module Weka
       #
       # @return [Hash] a hash as described above
       def attribute_values_to_hash(attribute_values)
-        attribute_names(true).each_with_object({}).with_index do |(attr_name, hash), index|
+        names = attribute_names(true)
+        names << class_attribute.name.to_sym if class_attribute_defined?
+        names.each_with_object({}).with_index do |(attr_name, hash), index|
           hash[attr_name] = attribute_values[index]
         end
       end

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -49,16 +49,16 @@ module Weka
         enumerate_instances.to_a
       end
 
-      def attributes
-        enumerate_attributes.to_a
+      def attributes(include_class_attribute = false)
+        attrs = enumerate_attributes.to_a
+        if include_class_attribute && class_attribute_defined?
+          attrs.insert(class_index, class_attribute)
+        end
+        attrs
       end
 
-      def attribute_names(use_symbol = false)
-        if use_symbol
-          attributes.map { |attribute| attribute.name.to_sym }
-        else
-          attributes.map(&:name)
-        end
+      def attribute_names(include_class_attribute = false)
+        attributes(include_class_attribute).map(&:name)
       end
 
       def add_attributes(&block)
@@ -318,8 +318,7 @@ module Weka
       # @return [Array] an array containing attribute values in the
       #   correct order
       def attribute_values_from_hash(attribute_values)
-        names = attribute_names(true)
-        names << class_attribute.name.to_sym if class_attribute_defined?
+        names = attribute_names(true).map!(&:to_sym)
         names.inject([]) do |values, attribute_name|
           values << attribute_values[attribute_name]
         end
@@ -334,8 +333,7 @@ module Weka
       #
       # @return [Hash] a hash as described above
       def attribute_values_to_hash(attribute_values)
-        names = attribute_names(true)
-        names << class_attribute.name.to_sym if class_attribute_defined?
+        names = attribute_names(true).map!(&:to_sym)
         names.each_with_object({}).with_index do |(attr_name, hash), index|
           hash[attr_name] = attribute_values[index]
         end

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -277,9 +277,9 @@ module Weka
       end
 
       def attribute_with_name(name)
-        attributes(include_class_attribute: true).select do |attribute|
+        attributes(include_class_attribute: true).find do |attribute|
           attribute.name == name.to_s
-        end.first
+        end
       end
 
       # Wrap the attribute values for the instance to be added with

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -151,21 +151,15 @@ describe Weka::Core::Instances do
       expect(subject.attribute_names).to eq names
     end
 
-    context 'if use_symbol is true' do
-      it 'returns an Array of the symbols of the attribute names' do
-        expect(subject.attribute_names(true)).to eq names.map(&:to_sym)
-      end
-    end
-
     context 'if class attribute is set' do
       subject do
         instances = load_instances('weather.arff')
-        instances.class_attribute = :play
+        instances.class_attribute = :windy
         instances
       end
 
       it 'does not return the class attribute' do
-        expect(subject.attribute_names).to eq(names.reject { |n| n == 'play' })
+        expect(subject.attribute_names).to eq(names.reject { |n| n == 'windy' })
       end
     end
   end
@@ -519,7 +513,7 @@ describe Weka::Core::Instances do
       context 'when class attribute is set' do
         subject do
           instances = load_instances('weather.arff')
-          instances.class_attribute = :play
+          instances.class_attribute = :windy
           instances
         end
 
@@ -599,7 +593,7 @@ describe Weka::Core::Instances do
       context 'when class attribute is set' do
         subject do
           instances = load_instances('weather.arff')
-          instances.class_attribute = :play
+          instances.class_attribute = :windy
           instances
         end
 

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -508,7 +508,7 @@ describe Weka::Core::Instances do
       [[:sunny, 70, 80, :TRUE, :yes], [:overcast, 80, 85, :FALSE, :yes]]
     end
 
-    context 'when passing array of attribute values' do
+    context 'when each instance is stored as an array of attribute values' do
       it 'adds the data to the Instances object' do
         expect { subject.add_instances(data) }
           .to change { subject.instances_count }
@@ -516,7 +516,7 @@ describe Weka::Core::Instances do
       end
     end
 
-    context 'when passing array of attribute values' do
+    context 'when each instance is stored as a hash of attribute values' do
       let(:hash_data) do
         data.map do |attribute_values|
           subject.send(:attribute_values_to_hash, attribute_values)

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -145,9 +145,16 @@ describe Weka::Core::Instances do
   end
 
   describe '#attribute_names' do
+    names = %w(outlook temperature humidity windy play)
+
     it 'returns an Array of the attribute names' do
-      names = %w(outlook temperature humidity windy play)
       expect(subject.attribute_names).to eq names
+    end
+
+    context 'if use_symbol is true' do
+      it 'returns an Array of the symbols of the attribute names' do
+        expect(subject.attribute_names(true)).to eq names.map(&:to_sym)
+      end
     end
   end
 
@@ -501,10 +508,26 @@ describe Weka::Core::Instances do
       [[:sunny, 70, 80, :TRUE, :yes], [:overcast, 80, 85, :FALSE, :yes]]
     end
 
-    it 'adds the data to the Instances object' do
-      expect { subject.add_instances(data) }
-        .to change { subject.instances_count }
-        .by(data.count)
+    context 'when passing array of attribute values' do
+      it 'adds the data to the Instances object' do
+        expect { subject.add_instances(data) }
+          .to change { subject.instances_count }
+          .by(data.count)
+      end
+    end
+
+    context 'when passing array of attribute values' do
+      let(:hash_data) do
+        data.map do |attribute_values|
+          subject.send(:attribute_values_to_hash, attribute_values)
+        end
+      end
+
+      it 'adds the data to the Instances object' do
+        expect { subject.add_instances(hash_data) }
+          .to change { subject.instances_count }
+          .by(hash_data.count)
+      end
     end
 
     it 'calls #add_instance internally' do

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -473,7 +473,7 @@ describe Weka::Core::Instances do
       end
     end
 
-    context 'when passing an hash of attribute values' do
+    context 'when passing a hash of attribute values' do
       it 'adds an instance from given values to the Instances object' do
         data = {
           outlook: :sunny,

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -2,7 +2,14 @@ require 'spec_helper'
 require 'fileutils'
 
 describe Weka::Core::Instances do
-  subject { load_instances('weather.arff') }
+  let(:set_class_attribute)   { false }
+  let(:class_attribute_name)  { :windy }
+
+  subject do
+    instances = load_instances('weather.arff')
+    instances.class_attribute = class_attribute_name if set_class_attribute
+    instances
+  end
 
   it { is_expected.to respond_to :each }
   it { is_expected.to respond_to :each_with_index }
@@ -142,6 +149,27 @@ describe Weka::Core::Instances do
 
       expect(all_kind_of_attribute).to be true
     end
+
+    context 'when class attribute is not set' do
+      it 'returns all attributes' do
+        expect(subject.attributes.size).to eq subject.attributes_count
+        expect(subject.attributes(include_class_attribute: true).size)
+          .to eq subject.attributes_count
+      end
+    end
+
+    context 'when class attribute is set' do
+      let(:set_class_attribute) { true }
+
+      it 'returns all attributes if include_class_attribute is true' do
+        expect(subject.attributes(include_class_attribute: true).size)
+          .to eq subject.attributes_count
+      end
+
+      it 'skips the class attribute if include_class_attribute is false' do
+        expect(subject.attributes.size).to eq(subject.attributes_count-1)
+      end
+    end
   end
 
   describe '#attribute_names' do
@@ -151,15 +179,17 @@ describe Weka::Core::Instances do
       expect(subject.attribute_names).to eq names
     end
 
-    context 'if class attribute is set' do
-      subject do
-        instances = load_instances('weather.arff')
-        instances.class_attribute = :windy
-        instances
+    context 'when class attribute is set' do
+      let(:set_class_attribute) { true }
+
+      it 'skips the class attribute if include_class_attribute is false' do
+        expect(subject.attribute_names)
+          .not_to include subject.class_attribute.name
       end
 
-      it 'does not return the class attribute' do
-        expect(subject.attribute_names).to eq(names.reject { |n| n == 'windy' })
+      it 'returns all attributes if include_class_attribute is true' do
+        expect(subject.attribute_names(include_class_attribute: true))
+          .to include subject.class_attribute.name
       end
     end
   end
@@ -284,6 +314,20 @@ describe Weka::Core::Instances do
       expect { subject.class_attribute = :not_existing_attribute }
         .to raise_error(ArgumentError)
     end
+
+    context 'when class attribute is already set' do
+      let(:set_class_attribute) { true }
+
+      it 'can set the same attribute as class attribute again' do
+        subject.class_attribute = class_attribute_name
+        expect(subject.class_attribute.name).to eq class_attribute_name.to_s
+      end
+
+      it 'can set another attribute as class attribute' do
+        subject.class_attribute = :play
+        expect(subject.class_attribute.name).to eq :play.to_s
+      end
+    end
   end
 
   describe '#class_attribute' do
@@ -336,12 +380,12 @@ describe Weka::Core::Instances do
     it 'adds the numbers of attributes given in the block' do
       instances = Weka::Core::Instances.new
 
-      expect {
+      expect do
         instances.add_attributes do
           numeric 'attribute'
           nominal 'class', values: %w(YES NO)
         end
-      }.to change { instances.attributes.count }.from(0).to(2)
+      end.to change { instances.attributes.count }.from(0).to(2)
     end
 
     it 'adds the types of attributes given in the block' do
@@ -449,7 +493,6 @@ describe Weka::Core::Instances do
   end
 
   describe '#add_instance' do
-
     context 'when passing an array of attribute values' do
       it 'adds an instance from given values to the Instances object' do
         data = [:sunny, 70, 80, 'TRUE', :yes]
@@ -480,6 +523,10 @@ describe Weka::Core::Instances do
     end
 
     context 'when passing a hash of attribute values' do
+      let(:humidity_value)  { 80 }
+      let(:windy_value)     { 'TRUE' }
+      let(:play_value)      { :yes }
+
       let(:data) do
         {
           outlook: :sunny,
@@ -489,10 +536,6 @@ describe Weka::Core::Instances do
           play: play_value
         }
       end
-
-      let(:humidity_value)  { 80 }
-      let(:windy_value)     { 'TRUE' }
-      let(:play_value)      { :yes }
 
       it 'adds an instance from given values to the Instances object' do
         subject.add_instance(data)
@@ -511,11 +554,7 @@ describe Weka::Core::Instances do
       end
 
       context 'when class attribute is set' do
-        subject do
-          instances = load_instances('weather.arff')
-          instances.class_attribute = :windy
-          instances
-        end
+        let(:set_class_attribute) { true }
 
         it 'adds a given instance to the Instances object' do
           subject.add_instance(data)
@@ -540,8 +579,13 @@ describe Weka::Core::Instances do
 
     context 'when each instance is stored as a hash of attribute values' do
       let(:hash_data) do
+        names = subject.attribute_names(include_class_attribute: true)
+                       .map(&:to_sym)
+
         data.map do |attribute_values|
-          subject.send(:attribute_values_to_hash, attribute_values)
+          names.each_with_index.inject({}) do |hash, (name, index)|
+            hash.update(name => attribute_values[index])
+          end
         end
       end
 
@@ -559,7 +603,6 @@ describe Weka::Core::Instances do
   end
 
   describe '#internal_values_of' do
-
     context 'when passing an array' do
       it 'returns an array of internal values of the given values' do
         values = [:sunny, 85, 85, :FALSE, :no]
@@ -570,32 +613,32 @@ describe Weka::Core::Instances do
     end
 
     context 'when passing a hash' do
-      values = {
-        outlook: :sunny,
-        temperature: 85,
-        humidity: 85,
-        windy: :FALSE,
-        play: :no
-      }
+      let(:values) do
+        {
+          outlook: :sunny,
+          temperature: 85,
+          humidity: 85,
+          windy: :FALSE,
+          play: :no
+        }
+      end
 
-      internal_values = {
-        outlook: 0,
-        temperature: 85.0,
-        humidity: 85.0,
-        windy: 1,
-        play: 1
-      }
+      let(:internal_values) do
+        {
+          outlook: 0,
+          temperature: 85.0,
+          humidity: 85.0,
+          windy: 1,
+          play: 1
+        }
+      end
 
       it 'returns a hash of internal values of the given values' do
         expect(subject.internal_values_of(values)).to eq internal_values
       end
 
       context 'when class attribute is set' do
-        subject do
-          instances = load_instances('weather.arff')
-          instances.class_attribute = :windy
-          instances
-        end
+        let(:set_class_attribute) { true }
 
         it 'return the index of the class attribute' do
           expect(subject.internal_values_of(values)).to eq internal_values

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -436,31 +436,63 @@ describe Weka::Core::Instances do
   end
 
   describe '#add_instance' do
-    it 'adds an instance from given values to the Instances object' do
-      data = [:sunny, 70, 80, 'TRUE', :yes]
-      subject.add_instance(data)
 
-      expect(subject.instances.last.to_s).to eq data.join(',')
+    context 'when passing an array of attribute values' do
+      it 'adds an instance from given values to the Instances object' do
+        data = [:sunny, 70, 80, 'TRUE', :yes]
+        subject.add_instance(data)
+
+        expect(subject.instances.last.to_s).to eq data.join(',')
+      end
+
+      it 'adds a given instance to the Instances object' do
+        data = subject.first
+        subject.add_instance(data)
+
+        expect(subject.instances.last.to_s).to eq data.to_s
+      end
+
+      it 'adds a given instance with only missing values' do
+        data = Weka::Core::DenseInstance.new(subject.size)
+        subject.add_instance(data)
+        expect(subject.instances.last.to_s).to eq data.to_s
+      end
+
+      it 'adds a given instance with partly missing values' do
+        data = [:sunny, 70, nil, '?', Float::NAN]
+        subject.add_instance(data)
+
+        expect(subject.instances.last.to_s).to eq 'sunny,70,?,?,?'
+      end
     end
 
-    it 'adds a given instance to the Instances object' do
-      data = subject.first
-      subject.add_instance(data)
+    context 'when passing an hash of attribute values' do
+      it 'adds an instance from given values to the Instances object' do
+        data = {
+          outlook: :sunny,
+          temperature: 70,
+          humidity: 80,
+          windy: 'TRUE',
+          play: :yes
+        }
+        subject.add_instance(data)
 
-      expect(subject.instances.last.to_s).to eq data.to_s
-    end
+        expect(subject.instances.last.to_s).to eq data.values.join(',')
+      end
 
-    it 'adds a given instance with only missing values' do
-      data = Weka::Core::DenseInstance.new(subject.size)
-      subject.add_instance(data)
-      expect(subject.instances.last.to_s).to eq data.to_s
-    end
+      it 'adds a given instance with partly missing values' do
+        data = {
+          outlook: :sunny,
+          temperature: 70,
+          humidity: nil,
+          windy: '?',
+          play: Float::NAN
+        }
+        subject.add_instance(data)
 
-    it 'adds a given instance with partly missing values' do
-      data = [:sunny, 70, nil, '?', Float::NAN]
-      subject.add_instance(data)
+        expect(subject.instances.last.to_s).to eq 'sunny,70,?,?,?'
+      end
 
-      expect(subject.instances.last.to_s).to eq 'sunny,70,?,?,?'
     end
   end
 
@@ -482,11 +514,36 @@ describe Weka::Core::Instances do
   end
 
   describe '#internal_values_of' do
-    it 'returns the internal values of the given values' do
-      values          = [:sunny, 85, 85, :FALSE, :no]
-      internal_values = [0, 85.0, 85.0, 1, 1]
 
-      expect(subject.internal_values_of(values)).to eq internal_values
+    context 'when passing an array' do
+      it 'returns an array of internal values of the given values' do
+        values = [:sunny, 85, 85, :FALSE, :no]
+        internal_values = [0, 85.0, 85.0, 1, 1]
+
+        expect(subject.internal_values_of(values)).to eq internal_values
+      end
+    end
+
+    context 'when passing a hash' do
+      it 'returns a hash of internal values of the given values' do
+        values = {
+          outlook: :sunny,
+          temperature: 85,
+          humidity: 85,
+          windy: :FALSE,
+          play: :no
+        }
+
+        internal_values = {
+          outlook: 0,
+          temperature: 85.0,
+          humidity: 85.0,
+          windy: 1,
+          play: 1
+        }
+
+        expect(subject.internal_values_of(values)).to eq internal_values
+      end
     end
   end
 

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -640,7 +640,7 @@ describe Weka::Core::Instances do
       context 'when class attribute is set' do
         let(:set_class_attribute) { true }
 
-        it 'return the index of the class attribute' do
+        it 'returns a hash of internal values of the given values' do
           expect(subject.internal_values_of(values)).to eq internal_values
         end
       end


### PR DESCRIPTION
At the moment adding instance can only be done by providing an Instance or an array of attribute values sorted according to the attribute order. It would be nice to be able to pass a hash of attribute values so we don't have to care about the order.