### PR TITLE
Add to_m to Core::Instances

### DIFF
--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -10,6 +10,7 @@ module Weka
     java_import 'weka.core.FastVector'
 
     class Instances
+      include Weka::Concerns::Persistent
       include Weka::Concerns::Serializable
 
       DEFAULT_RELATION_NAME = 'Instances'.freeze
@@ -355,7 +356,5 @@ module Weka
         end
       end
     end
-
-    Java::WekaCore::Instances.__persistent__ = true
   end
 end

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -40,7 +40,7 @@ module Weka
         end
       end
 
-      def initialize(relation_name: DEFAULT_RELATION_NAME, attributes: [], &block)
+      def initialize(relation_name: DEFAULT_RELATION_NAME, attributes: [])
         attribute_list = FastVector.new
         attributes.each { |attribute| attribute_list.add_element(attribute) }
 

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -1,3 +1,4 @@
+require 'matrix'
 require 'weka/core/converters'
 require 'weka/core/loader'
 require 'weka/core/saver'
@@ -257,6 +258,13 @@ module Weka
         instances.inject(self) do |merged_instances, dataset|
           self.class.merge_instances(merged_instances, dataset)
         end
+      end
+
+      # Get the all instances's values as Matrix.
+      #
+      # @return [Matrix] a Matrix holding the instance's values as rows.
+      def to_m
+        Matrix[*instances.map(&:values)]
       end
 
       private

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'fileutils'
+require 'matrix'
 
 describe Weka::Core::Instances do
   let(:class_attribute_name) { :windy }
@@ -34,6 +35,7 @@ describe Weka::Core::Instances do
   it { is_expected.to respond_to :reset_class_attribute }
 
   it { is_expected.to respond_to :serialize }
+  it { is_expected.to respond_to :to_m }
 
   describe 'aliases:' do
     let(:instances) { described_class.new }
@@ -802,6 +804,31 @@ describe Weka::Core::Instances do
       it 'returns false for undefined attribute type' do
         expect(subject.has_attribute_type?(-1)).to be false
       end
+    end
+  end
+
+  describe '#to_m' do
+    subject { load_instances('weather.arff') }
+
+    it 'returns a matrix of all instance values' do
+      matrix = Matrix[
+        ['sunny', 85.0, 85.0, 'FALSE', 'no'],
+        ['sunny', 80.0, 90.0, 'TRUE', 'no'],
+        ['overcast', 83.0, 86.0, 'FALSE', 'yes'],
+        ['rainy', 70.0, 96.0, 'FALSE', 'yes'],
+        ['rainy', 68.0, 80.0, 'FALSE', 'yes'],
+        ['rainy', 65.0, 70.0, 'TRUE', 'no'],
+        ['overcast', 64.0, 65.0, 'TRUE', 'yes'],
+        ['sunny', 72.0, 95.0, 'FALSE', 'no'],
+        ['sunny', 69.0, 70.0, 'FALSE', 'yes'],
+        ['rainy', 75.0, 80.0, 'FALSE', 'yes'],
+        ['sunny', 75.0, 70.0, 'TRUE', 'yes'],
+        ['overcast', 72.0, 90.0, 'TRUE', 'yes'],
+        ['overcast', 81.0, 75.0, 'FALSE', 'yes'],
+        ['rainy', 71.0, 91.0, 'TRUE', 'no']
+      ]
+
+      expect(subject.to_m).to eq matrix
     end
   end
 end


### PR DESCRIPTION
Addresses the [proposal](https://github.com/paulgoetze/weka-jruby/issues/17#issuecomment-269916276) from #17 and adds an additional `to_m` (to Matrix) convenience method to to the `Weka::Core::Instances` class.