### PR TITLE
Add curve classes to classifier evaluator namespace

### DIFF
--- a/lib/weka/classifiers/evaluation.rb
+++ b/lib/weka/classifiers/evaluation.rb
@@ -1,8 +1,12 @@
+require 'weka/class_builder'
+
 module Weka
   module Classifiers
     java_import 'weka.classifiers.Evaluation'
 
     class Evaluation
+      include ClassBuilder
+
       # Use both nomenclatures f_measure and fmeasure for consistency
       # due to jruby's auto method generation of 'fMeasure' to 'f_measure' and
       # 'weightedFMeasure' to 'weighted_fmeasure'.
@@ -29,8 +33,11 @@ module Weka
       alias average_cost            avg_cost
 
       alias cumulative_margin_distribution to_cumulative_margin_distribution_string
-    end
 
-    Java::WekaClassifiers::Evaluation.__persistent__ = true
+      build_classes :CostCurve,
+                    :MarginCurve,
+                    :ThresholdCurve,
+                    weka_module: 'weka.classifiers.evaluation'
+    end
   end
 end

--- a/lib/weka/classifiers/evaluation.rb
+++ b/lib/weka/classifiers/evaluation.rb
@@ -34,10 +34,19 @@ module Weka
 
       alias cumulative_margin_distribution to_cumulative_margin_distribution_string
 
+      module Curve
+        def self.included(base)
+          base.class_eval do
+            alias_method :curve, :get_curve
+          end
+        end
+      end
+
       build_classes :CostCurve,
                     :MarginCurve,
                     :ThresholdCurve,
-                    weka_module: 'weka.classifiers.evaluation'
+                    weka_module: 'weka.classifiers.evaluation',
+                    additional_includes: Curve
     end
   end
 end

--- a/spec/classifiers/evaluation_spec.rb
+++ b/spec/classifiers/evaluation_spec.rb
@@ -35,4 +35,16 @@ describe Weka::Classifiers::Evaluation do
       end
     end
   end
+
+  it_behaves_like 'class builder'
+
+  %i[
+    CostCurve
+    MarginCurve
+    ThresholdCurve
+  ].each do |class_name|
+    it "defines a class #{class_name}" do
+      expect(described_class.const_defined?(class_name)).to be true
+    end
+  end
 end

--- a/spec/classifiers/evaluation_spec.rb
+++ b/spec/classifiers/evaluation_spec.rb
@@ -1,11 +1,13 @@
 require 'spec_helper'
 
 describe Weka::Classifiers::Evaluation do
-  subject do
+  let(:instances) do
     instances = load_instances('weather.arff')
     instances.class_attribute = :play
-    Weka::Classifiers::Evaluation.new(instances)
+    instances
   end
+
+  subject { Weka::Classifiers::Evaluation.new(instances) }
 
   it { is_expected.to be_kind_of(Java::WekaClassifiers::Evaluation) }
 
@@ -45,6 +47,47 @@ describe Weka::Classifiers::Evaluation do
   ].each do |class_name|
     it "defines a class #{class_name}" do
       expect(described_class.const_defined?(class_name)).to be true
+    end
+
+    describe "#{class_name}" do
+      let(:curve) do
+        Object.module_eval("Weka::Classifiers::Evaluation::#{class_name}").new
+      end
+
+      it 'responds to #curve' do
+        expect(curve).to respond_to :curve
+      end
+
+      describe '#curve' do
+        let(:classifier) do
+          classifier = Weka::Classifiers::Bayes::NaiveBayes.new
+          classifier.train_with_instances(instances)
+          classifier
+        end
+
+        context 'without class index' do
+          it 'returns Instances for predictions' do
+            evaluation = classifier.cross_validate
+            curve_instances = curve.curve(evaluation.predictions)
+
+            expect(curve_instances).to be_a Weka::Core::Instances
+          end
+        end
+
+        unless class_name == :MarginCurve
+          context 'with class index' do
+            it 'returns Instances for predictions' do
+              evaluation = classifier.cross_validate
+
+              instances.class_attribute.values.each do |value|
+                class_index = instances.class_attribute.internal_value_of(value)
+                curve_instances = curve.curve(evaluation.predictions, class_index)
+                expect(curve_instances).to be_a Weka::Core::Instances
+              end
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The evaluator Curve classes are handy to generate curve data, e.g. if you like to visualise the results of a cross validation of a classifier.

We need to define the Curve classes inside of the  `Weka::Classifiers::Evaluator` *class*, because we cannot have a class and a module with the same name *Evaluator* in Ruby.

