### PR TITLE
Fix: unassigned training instance issues

### DIFF
--- a/lib/weka/class_builder.rb
+++ b/lib/weka/class_builder.rb
@@ -103,7 +103,7 @@ module Weka
       end
 
       def constantize(module_names)
-        Object.module_eval("::#{module_names}")
+        Object.module_eval("::#{module_names}", __FILE__, __LINE__)
       end
 
       def utils

--- a/lib/weka/classifiers/evaluation.rb
+++ b/lib/weka/classifiers/evaluation.rb
@@ -1,4 +1,5 @@
 require 'weka/class_builder'
+require 'weka/concerns'
 
 module Weka
   module Classifiers
@@ -6,6 +7,7 @@ module Weka
 
     class Evaluation
       include ClassBuilder
+      include Weka::Concerns::Persistent
 
       # Use both nomenclatures f_measure and fmeasure for consistency
       # due to jruby's auto method generation of 'fMeasure' to 'f_measure' and

--- a/lib/weka/classifiers/utils.rb
+++ b/lib/weka/classifiers/utils.rb
@@ -69,10 +69,9 @@ module Weka
         private
 
         def classifiable_instance_from(instance_or_values)
-          instances = instances_structure.copy
-          instances.add_instance(instance_or_values)
+          ensure_instances_structure_available!
 
-          instance = instances.first
+          instance = instances_structure.instance_from(instance_or_values)
           instance.set_class_missing
           instance
         end
@@ -132,8 +131,6 @@ module Weka
         include Transformers
 
         def classify(instance_or_values)
-          ensure_instances_structure_available!
-
           instance = classifiable_instance_from(instance_or_values)
           index    = classify_instance(instance)
 
@@ -167,8 +164,6 @@ module Weka
         include Transformers
 
         def distribution_for(instance_or_values)
-          ensure_instances_structure_available!
-
           instance      = classifiable_instance_from(instance_or_values)
           distributions = distribution_for_instance(instance)
 

--- a/lib/weka/classifiers/utils.rb
+++ b/lib/weka/classifiers/utils.rb
@@ -1,4 +1,3 @@
-require 'weka/core/serialization_helper'
 require 'weka/classifiers/evaluation'
 require 'weka/core/instances'
 
@@ -44,7 +43,7 @@ module Weka
           return if training_instances.nil?
           return if instances.equal_headers(training_instances)
 
-          message = 'The passed instances need to have the same structure as ' +
+          message = 'The passed instances need to have the same structure as ' \
                     'the classifier’s training instances.'
 
           raise InvalidInstancesStructureError, message
@@ -53,12 +52,13 @@ module Weka
         def ensure_instances_structure_available!
           return unless instances_structure.nil?
 
-          error   = "Classifier does not have any instances structure info."
-          hint    = 'You probably tried to classify values with a classifier ' +
-                    'that is untrained or doesn’t have an instances_structure ' +
-                    'set. Please run #train_with_instances, try serializing ' +
-                    'and deserializing your classifier again in case you used ' +
-                    'a deserialized classifier or set its instances_structure.'
+          error   = 'Classifier does not have any instances structure info.'
+          hint    = 'You probably tried to classify values with a ' \
+                    'classifier that is untrained or doesn’t have an ' \
+                    'instances_structure set. Please run ' \
+                    '#train_with_instances, try serializing and ' \
+                    'deserializing your classifier again in case you used a ' \
+                    'deserialized classifier or set its instances_structure.'
           message = "#{error}\n#{hint}"
 
           raise MissingInstancesStructureError, message

--- a/lib/weka/classifiers/utils.rb
+++ b/lib/weka/classifiers/utils.rb
@@ -1,3 +1,4 @@
+require 'weka/core/serialization_helper'
 require 'weka/classifiers/evaluation'
 require 'weka/core/instances'
 
@@ -19,7 +20,7 @@ module Weka
 
           error   = 'Class attribute is not assigned for Instances.'
           hint    = 'You can assign a class attribute with #class_attribute=.'
-          message = "#{error} #{hint}"
+          message = "#{error}\n#{hint}"
 
           raise UnassignedClassError, message
         end
@@ -29,9 +30,38 @@ module Weka
 
           error   = 'Classifier is not trained with Instances.'
           hint    = 'You can set the training instances with #train_with_instances.'
-          message = "#{error} #{hint}"
+          message = "#{error}\n#{hint}"
 
           raise UnassignedTrainingInstancesError, message
+        end
+
+        def ensure_valid_instances_structure!(instances)
+          unless instances.is_a?(Weka::Core::Instances)
+            message = 'Instances has to be a Weka::Core::Instances object.'
+            raise ArgumentError, message
+          end
+
+          return if training_instances.nil?
+          return if instances.equal_headers(training_instances)
+
+          message = 'The passed instances need to have the same structure as ' +
+                    'the classifier’s training instances.'
+
+          raise InvalidInstancesStructureError, message
+        end
+
+        def ensure_instances_structure_available!
+          return unless instances_structure.nil?
+
+          error   = "Classifier does not have any instances structure info."
+          hint    = 'You probably tried to classify values with a classifier ' +
+                    'that is untrained or doesn’t have an instances_structure ' +
+                    'set. Please run #train_with_instances, try serializing ' +
+                    'and deserializing your classifier again in case you used ' +
+                    'a deserialized classifier or set its instances_structure.'
+          message = "#{error}\n#{hint}"
+
+          raise MissingInstancesStructureError, message
         end
       end
 
@@ -39,14 +69,7 @@ module Weka
         private
 
         def classifiable_instance_from(instance_or_values)
-          attributes = training_instances.attributes
-          instances  = Weka::Core::Instances.new(attributes: attributes)
-
-          class_attribute = training_instances.class_attribute
-          class_index     = training_instances.class_index
-          instances.insert_attribute_at(class_attribute, class_index)
-
-          instances.class_index = training_instances.class_index
+          instances = instances_structure.copy
           instances.add_instance(instance_or_values)
 
           instance = instances.first
@@ -60,14 +83,22 @@ module Weka
         include Checks
 
         attr_reader :training_instances
+        attr_reader :instances_structure
 
         def train_with_instances(instances)
           ensure_class_attribute_assigned!(instances)
 
           @training_instances = instances
+          @instances_structure = instances.string_free_structure
+
           build_classifier(instances)
 
           self
+        end
+
+        def instances_structure=(instances)
+          ensure_valid_instances_structure!(instances)
+          @instances_structure = instances.string_free_structure
         end
 
         def cross_validate(folds: 3)
@@ -101,7 +132,7 @@ module Weka
         include Transformers
 
         def classify(instance_or_values)
-          ensure_trained_with_instances!
+          ensure_instances_structure_available!
 
           instance = classifiable_instance_from(instance_or_values)
           index    = classify_instance(instance)
@@ -112,7 +143,7 @@ module Weka
         private
 
         def class_value_of_index(index)
-          training_instances.class_attribute.value(index)
+          instances_structure.class_attribute.value(index)
         end
       end
 
@@ -136,7 +167,7 @@ module Weka
         include Transformers
 
         def distribution_for(instance_or_values)
-          ensure_trained_with_instances!
+          ensure_instances_structure_available!
 
           instance      = classifiable_instance_from(instance_or_values)
           distributions = distribution_for_instance(instance)
@@ -147,7 +178,7 @@ module Weka
         private
 
         def class_distributions_from(distributions)
-          class_values = training_instances.class_attribute.values
+          class_values = instances_structure.class_attribute.values
 
           distributions.each_with_object({}).with_index do |(distribution, result), index|
             class_value = class_values[index]

--- a/lib/weka/clusterers/utils.rb
+++ b/lib/weka/clusterers/utils.rb
@@ -41,7 +41,7 @@ module Weka
           return if training_instances.nil?
           return if instances.equal_headers(training_instances)
 
-          message = 'The passed instances need to have the same structure as ' +
+          message = 'The passed instances need to have the same structure as ' \
                     'the clusterers training instances.'
 
           raise InvalidInstancesStructureError, message
@@ -50,12 +50,13 @@ module Weka
         def ensure_instances_structure_available!
           return unless instances_structure.nil?
 
-          error   = "Clusterer does not have any instances structure info."
-          hint    = 'You probably tried to cluster values with a clusterer ' +
-                    'that is untrained or doesn’t have an instances_structure ' +
-                    'set. Please run #train_with_instances, try serializing ' +
-                    'and deserializing your clusterer again in case you used ' +
-                    'a deserialized clusterer or set its instances_structure.'
+          error   = 'Clusterer does not have any instances structure info.'
+          hint    = 'You probably tried to cluster values with a clusterer ' \
+                    'that is untrained or doesn’t have an ' \
+                    'instances_structure set. Please run ' \
+                    '#train_with_instances, try serializing and ' \
+                    'deserializing your clusterer again in case you used a ' \
+                    'deserialized clusterer or set its instances_structure.'
           message = "#{error}\n#{hint}"
 
           raise MissingInstancesStructureError, message

--- a/lib/weka/clusterers/utils.rb
+++ b/lib/weka/clusterers/utils.rb
@@ -63,16 +63,6 @@ module Weka
         end
       end
 
-      module Transformers
-        private
-
-        def clusterable_instance_from(instance_or_values)
-          instances = instances_structure.copy
-          instances.add_instance(instance_or_values)
-          instances.first
-        end
-      end
-
       module Buildable
         include Checks
 
@@ -121,12 +111,11 @@ module Weka
 
       module Clusterable
         include Checks
-        include Transformers
 
         def cluster(instance_or_values)
           ensure_instances_structure_available!
 
-          instance = clusterable_instance_from(instance_or_values)
+          instance = instances_structure.instance_from(instance_or_values)
           cluster_instance(instance)
         end
       end
@@ -148,12 +137,11 @@ module Weka
 
       module Distributable
         include Checks
-        include Transformers
 
         def distribution_for(instance_or_values)
           ensure_instances_structure_available!
 
-          instance = clusterable_instance_from(instance_or_values)
+          instance = instances_structure.instance_from(instance_or_values)
           distribution_for_instance(instance).to_a
         end
       end

--- a/lib/weka/core/instances.rb
+++ b/lib/weka/core/instances.rb
@@ -47,6 +47,11 @@ module Weka
         super(relation_name.to_s, attribute_list, 0)
       end
 
+      def copy
+        constructor = Instances.java_class.declared_constructor(Instances)
+        constructor.new_instance(self).to_java(Instances)
+      end
+
       def instances
         enumerate_instances.to_a
       end

--- a/lib/weka/core/serialization_helper.rb
+++ b/lib/weka/core/serialization_helper.rb
@@ -3,9 +3,45 @@ module Weka
     java_import 'weka.core.SerializationHelper'
 
     class SerializationHelper
+      STRUCTURE_FILE_EXTENSION = 'structure'
+
       class << self
+        original_read = instance_method(:read)
+        original_write = instance_method(:write)
+
+        define_method(:read) do |filename|
+          object = original_read.bind(self).(filename)
+
+          structure_filename = structure_file(filename)
+          structure_needed = object.respond_to?(:instances_structure)
+          structure_available = File.exist?(structure_filename)
+
+          if structure_needed && structure_available
+            structure = original_read.bind(self).(structure_filename)
+            object.instances_structure = structure
+          end
+
+          object
+        end
+
+        define_method(:write) do |filename, object|
+          if object.respond_to?(:instances_structure) && object.instances_structure
+            structure_filename = structure_file(filename)
+            structure = object.instances_structure
+            original_write.bind(self).(structure_filename, structure)
+          end
+
+          original_write.bind(self).(filename, object)
+        end
+
         alias deserialize read
         alias serialize   write
+
+        private
+
+        def structure_file(filename)
+          "#{filename}.#{STRUCTURE_FILE_EXTENSION}"
+        end
       end
     end
   end

--- a/lib/weka/core/serialization_helper.rb
+++ b/lib/weka/core/serialization_helper.rb
@@ -3,21 +3,21 @@ module Weka
     java_import 'weka.core.SerializationHelper'
 
     class SerializationHelper
-      STRUCTURE_FILE_EXTENSION = 'structure'
+      STRUCTURE_FILE_EXTENSION = 'structure'.freeze
 
       class << self
         original_read = instance_method(:read)
         original_write = instance_method(:write)
 
         define_method(:read) do |filename|
-          object = original_read.bind(self).(filename)
+          object = original_read.bind(self).call(filename)
 
           structure_filename = structure_file(filename)
           structure_needed = object.respond_to?(:instances_structure)
           structure_available = File.exist?(structure_filename)
 
           if structure_needed && structure_available
-            structure = original_read.bind(self).(structure_filename)
+            structure = original_read.bind(self).call(structure_filename)
             object.instances_structure = structure
           end
 
@@ -28,10 +28,10 @@ module Weka
           if object.respond_to?(:instances_structure) && object.instances_structure
             structure_filename = structure_file(filename)
             structure = object.instances_structure
-            original_write.bind(self).(structure_filename, structure)
+            original_write.bind(self).call(structure_filename, structure)
           end
 
-          original_write.bind(self).(filename, object)
+          original_write.bind(self).call(filename, object)
         end
 
         alias deserialize read

--- a/lib/weka/core/serialization_helper.rb
+++ b/lib/weka/core/serialization_helper.rb
@@ -25,7 +25,9 @@ module Weka
         end
 
         define_method(:write) do |filename, object|
-          if object.respond_to?(:instances_structure) && object.instances_structure
+          structure_needed = object.respond_to?(:instances_structure)
+
+          if structure_needed && object.instances_structure
             structure_filename = structure_file(filename)
             structure = object.instances_structure
             original_write.bind(self).call(structure_filename, structure)

--- a/lib/weka/exceptions.rb
+++ b/lib/weka/exceptions.rb
@@ -3,4 +3,6 @@ module Weka
 
   class UnassignedClassError < Error; end
   class UnassignedTrainingInstancesError < Error; end
+  class MissingInstancesStructureError < Error; end
+  class InvalidInstancesStructureError < Error; end
 end

--- a/spec/attribute_selection/evaluator_spec.rb
+++ b/spec/attribute_selection/evaluator_spec.rb
@@ -20,8 +20,11 @@ describe Weka::AttributeSelection::Evaluator do
     end
 
     it "inherits class #{class_name} from #{super_class_name}" do
-      evaluator_class = Object.module_eval("#{subject}::#{class_name}")
-      super_class     = Object.module_eval("#{subject}::#{super_class_name}")
+      scoped_class = "#{subject}::#{class_name}"
+      scoped_super_class = "#{subject}::#{super_class_name}"
+
+      evaluator_class = Object.module_eval(scoped_class, __FILE__, __LINE__)
+      super_class = Object.module_eval(scoped_super_class, __FILE__, __LINE__)
 
       expect(evaluator_class.new).to be_kind_of super_class
     end

--- a/spec/class_builder_spec.rb
+++ b/spec/class_builder_spec.rb
@@ -96,9 +96,11 @@ describe Weka::ClassBuilder do
       end
 
       before do
+        class_definition = "class #{class_name}; end"
+
         allow(subject)
           .to receive(:java_import)
-          .and_return(subject.module_eval("class #{class_name}; end"))
+          .and_return(subject.module_eval(class_definition, __FILE__, __LINE__))
       end
 
       it 'does not include extra methods in the defined class' do

--- a/spec/classifiers/evaluation_spec.rb
+++ b/spec/classifiers/evaluation_spec.rb
@@ -51,7 +51,8 @@ describe Weka::Classifiers::Evaluation do
 
     describe class_name.to_s do
       let(:curve) do
-        Object.module_eval("Weka::Classifiers::Evaluation::#{class_name}").new
+        evaluation_class_name = "Weka::Classifiers::Evaluation::#{class_name}"
+        Object.module_eval(evaluation_class_name, __FILE__, __LINE__).new
       end
 
       it 'responds to #curve' do

--- a/spec/classifiers/utils_spec.rb
+++ b/spec/classifiers/utils_spec.rb
@@ -364,8 +364,8 @@ describe Weka::Classifiers::Utils do
   end
 
   describe '#distribution_for' do
-    let(:instance)            { instances.first }
-    let(:values_array)        { [:overcast, 83, 86, :FALSE, '?'] }
+    let(:instance)     { instances.first }
+    let(:values_array) { [:overcast, 83, 86, :FALSE, '?'] }
     let(:values_hash) do
       {
         outlook: :overcast,
@@ -375,8 +375,13 @@ describe Weka::Classifiers::Utils do
         play: '?'
       }
     end
-    let(:distributions)       { [0.543684388757196, 0.4563156112428039] }
-    let(:class_distributions) { { 'yes' => distributions[0], 'no' => distributions[1] } }
+    let(:distributions) { [0.543684388757196, 0.4563156112428039] }
+    let(:class_distributions) do
+      {
+        'yes' => distributions[0],
+        'no' => distributions[1]
+      }
+    end
 
     before do
       allow(subject)
@@ -409,7 +414,8 @@ describe Weka::Classifiers::Utils do
         end
 
         it 'returns the predicted class distributions' do
-          expect(subject.distribution_for(values_array)).to eq class_distributions
+          expect(subject.distribution_for(values_array))
+            .to eq class_distributions
         end
       end
 
@@ -476,7 +482,8 @@ describe Weka::Classifiers::Utils do
         end
 
         it 'returns the predicted class distributions' do
-          expect(subject.distribution_for(values_array)).to eq class_distributions
+          expect(subject.distribution_for(values_array))
+            .to eq class_distributions
         end
       end
 

--- a/spec/classifiers/utils_spec.rb
+++ b/spec/classifiers/utils_spec.rb
@@ -219,8 +219,17 @@ describe Weka::Classifiers::Utils do
   end
 
   describe '#classify' do
-    let(:instance)    { instances.first }
-    let(:values)      { [:overcast, 83, 86, :FALSE, '?'] }
+    let(:instance)     { instances.first }
+    let(:values_array) { [:overcast, 83, 86, :FALSE, '?'] }
+    let(:values_hash) do
+      {
+        outlook: :overcast,
+        temperature: 83,
+        humidity: 86,
+        windy: :FALSE,
+        play: '?'
+      }
+    end
     let(:class_value) { 'no' }
     let(:class_index) { 1.0 }
 
@@ -238,7 +247,7 @@ describe Weka::Classifiers::Utils do
           subject.classify(instance)
         end
 
-        it 'returns the predicted class value of the instance' do
+        it 'returns the predicted class value' do
           expect(subject.classify(instance)).to eq class_value
         end
       end
@@ -249,11 +258,25 @@ describe Weka::Classifiers::Utils do
             .to receive(:classify_instance).once
             .with(an_instance_of(Weka::Core::DenseInstance))
 
-          subject.classify(values)
+          subject.classify(values_array)
         end
 
-        it 'returns the predicted class value of the instance' do
-          expect(subject.classify(values)).to eq class_value
+        it 'returns the predicted class value' do
+          expect(subject.classify(values_array)).to eq class_value
+        end
+      end
+
+      context 'with a given hash of values' do
+        it 'calls Java’s #classify_instance' do
+          expect(subject)
+            .to receive(:classify_instance).once
+            .with(an_instance_of(Weka::Core::DenseInstance))
+
+          subject.classify(values_hash)
+        end
+
+        it 'returns the predicted class value' do
+          expect(subject.classify(values_hash)).to eq class_value
         end
       end
 
@@ -294,7 +317,7 @@ describe Weka::Classifiers::Utils do
           subject.classify(instance)
         end
 
-        it 'returns the predicted class value of the instance' do
+        it 'returns the predicted class value' do
           expect(subject.classify(instance)).to eq class_value
         end
       end
@@ -305,11 +328,25 @@ describe Weka::Classifiers::Utils do
             .to receive(:classify_instance).once
             .with(an_instance_of(Weka::Core::DenseInstance))
 
-          subject.classify(values)
+          subject.classify(values_array)
         end
 
-        it 'returns the predicted class value of the instance' do
-          expect(subject.classify(values)).to eq class_value
+        it 'returns the predicted class value' do
+          expect(subject.classify(values_array)).to eq class_value
+        end
+      end
+
+      context 'with a given hash of values' do
+        it 'calls Java’s #classify_instance' do
+          expect(subject)
+            .to receive(:classify_instance).once
+            .with(an_instance_of(Weka::Core::DenseInstance))
+
+          subject.classify(values_hash)
+        end
+
+        it 'returns the predicted class value' do
+          expect(subject.classify(values_hash)).to eq class_value
         end
       end
 
@@ -328,7 +365,16 @@ describe Weka::Classifiers::Utils do
 
   describe '#distribution_for' do
     let(:instance)            { instances.first }
-    let(:values)              { [:overcast, 83, 86, :FALSE, '?'] }
+    let(:values_array)        { [:overcast, 83, 86, :FALSE, '?'] }
+    let(:values_hash) do
+      {
+        outlook: :overcast,
+        temperature: 83,
+        humidity: 86,
+        windy: :FALSE,
+        play: '?'
+      }
+    end
     let(:distributions)       { [0.543684388757196, 0.4563156112428039] }
     let(:class_distributions) { { 'yes' => distributions[0], 'no' => distributions[1] } }
 
@@ -348,7 +394,7 @@ describe Weka::Classifiers::Utils do
           subject.distribution_for(instance)
         end
 
-        it 'returns the predicted class distributions of the instance' do
+        it 'returns the predicted class distributions' do
           expect(subject.distribution_for(instance)).to eq class_distributions
         end
       end
@@ -359,11 +405,26 @@ describe Weka::Classifiers::Utils do
             .to receive(:distribution_for_instance).once
             .with(an_instance_of(Weka::Core::DenseInstance))
 
-          subject.distribution_for(values)
+          subject.distribution_for(values_array)
         end
 
-        it 'returns the predicted class distributions of the instance' do
-          expect(subject.distribution_for(values)).to eq class_distributions
+        it 'returns the predicted class distributions' do
+          expect(subject.distribution_for(values_array)).to eq class_distributions
+        end
+      end
+
+      context 'with a given hash of values' do
+        it 'calls Java’s #distribution_for_instance' do
+          expect(subject)
+            .to receive(:distribution_for_instance).once
+            .with(an_instance_of(Weka::Core::DenseInstance))
+
+          subject.distribution_for(values_hash)
+        end
+
+        it 'returns the predicted class distributions' do
+          expect(subject.distribution_for(values_hash))
+            .to eq class_distributions
         end
       end
 
@@ -400,7 +461,7 @@ describe Weka::Classifiers::Utils do
           subject.distribution_for(instance)
         end
 
-        it 'returns the predicted class distributions of the instance' do
+        it 'returns the predicted class distributions' do
           expect(subject.distribution_for(instance)).to eq class_distributions
         end
       end
@@ -411,11 +472,26 @@ describe Weka::Classifiers::Utils do
             .to receive(:distribution_for_instance).once
             .with(an_instance_of(Weka::Core::DenseInstance))
 
-          subject.distribution_for(values)
+          subject.distribution_for(values_array)
         end
 
-        it 'returns the predicted class distributions of the instance' do
-          expect(subject.distribution_for(values)).to eq class_distributions
+        it 'returns the predicted class distributions' do
+          expect(subject.distribution_for(values_array)).to eq class_distributions
+        end
+      end
+
+      context 'with a given hash of values' do
+        it 'calls Java’s #distribution_for_instance' do
+          expect(subject)
+            .to receive(:distribution_for_instance).once
+            .with(an_instance_of(Weka::Core::DenseInstance))
+
+          subject.distribution_for(values_hash)
+        end
+
+        it 'returns the predicted class distributions' do
+          expect(subject.distribution_for(values_hash))
+            .to eq class_distributions
         end
       end
 

--- a/spec/classifiers/utils_spec.rb
+++ b/spec/classifiers/utils_spec.rb
@@ -26,6 +26,7 @@ describe Weka::Classifiers::Utils do
   it { is_expected.to respond_to :cross_validate }
   it { is_expected.to respond_to :evaluate }
   it { is_expected.to respond_to :classify }
+  it { is_expected.to respond_to :distribution_for }
   it { is_expected.to respond_to :instances_structure }
   it { is_expected.to respond_to :instances_structure= }
 

--- a/spec/classifiers/utils_spec.rb
+++ b/spec/classifiers/utils_spec.rb
@@ -4,8 +4,11 @@ describe Weka::Classifiers::Utils do
   let(:including_class) do
     Class.new do
       def build_classifier(instances); end
+
       def update_classifier(instance); end
+
       def classify_instance; end
+
       def distribution_for_instance; end
 
       include Weka::Classifiers::Utils

--- a/spec/clusterers/utils_spec.rb
+++ b/spec/clusterers/utils_spec.rb
@@ -288,7 +288,9 @@ describe Weka::Clusterers::Utils do
       end
 
       context 'without an available instances structure' do
-        before { allow(subject).to receive(:instances_structure).and_return(nil) }
+        before do
+          allow(subject).to receive(:instances_structure).and_return(nil)
+        end
 
         it 'raises an MissingInstancesStructureError' do
           expect { subject.cluster(instance) }
@@ -354,7 +356,9 @@ describe Weka::Clusterers::Utils do
       end
 
       context 'without an available instances structure' do
-        before { allow(subject).to receive(:instances_structure).and_return(nil) }
+        before do
+          allow(subject).to receive(:instances_structure).and_return(nil)
+        end
 
         it 'raises an MissingInstancesStructureError' do
           expect { subject.cluster(instance) }
@@ -428,7 +432,9 @@ describe Weka::Clusterers::Utils do
       end
 
       context 'without an available instances structure' do
-        before { allow(subject).to receive(:instances_structure).and_return(nil) }
+        before do
+          allow(subject).to receive(:instances_structure).and_return(nil)
+        end
 
         it 'raises a MissingInstancesStructureError' do
           expect { subject.distribution_for(instance) }
@@ -496,7 +502,9 @@ describe Weka::Clusterers::Utils do
       end
 
       context 'without an available instances structure' do
-        before { allow(subject).to receive(:instances_structure).and_return(nil) }
+        before do
+          allow(subject).to receive(:instances_structure).and_return(nil)
+        end
 
         it 'raises a MissingInstancesStructureError' do
           expect { subject.distribution_for(instance) }

--- a/spec/clusterers/utils_spec.rb
+++ b/spec/clusterers/utils_spec.rb
@@ -4,8 +4,11 @@ describe Weka::Clusterers::Utils do
   let(:including_class) do
     Class.new do
       def build_clusterer(instances); end
+
       def update_clusterer(instance); end
+
       def cluster_instance; end
+
       def distribution_for_instance; end
 
       include Weka::Clusterers::Utils

--- a/spec/clusterers/utils_spec.rb
+++ b/spec/clusterers/utils_spec.rb
@@ -227,8 +227,17 @@ describe Weka::Clusterers::Utils do
   end
 
   describe '#cluster' do
-    let(:instance) { instances.first }
-    let(:values)   { [:overcast, 83, 86, :FALSE, :yes] }
+    let(:instance)     { instances.first }
+    let(:values_array) { [:overcast, 83, 86, :FALSE, :yes] }
+    let(:values_hash) do
+      {
+        outlook: :overcast,
+        temperature: 83,
+        humidity: 86,
+        windy: :FALSE,
+        play: :yes
+      }
+    end
     let(:cluster)  { 1 }
 
     context 'for a newly built clusterer' do
@@ -245,7 +254,7 @@ describe Weka::Clusterers::Utils do
           subject.cluster(instance)
         end
 
-        it 'returns the predicted class value of the instance' do
+        it 'returns the predicted class value' do
           expect(subject.cluster(instance)).to eq cluster
         end
       end
@@ -256,11 +265,25 @@ describe Weka::Clusterers::Utils do
             .to receive(:cluster_instance).once
             .with(an_instance_of(Weka::Core::DenseInstance))
 
-          subject.cluster(values)
+          subject.cluster(values_array)
         end
 
-        it 'returns the predicted class value of the instance' do
-          expect(subject.cluster(values)).to eq cluster
+        it 'returns the predicted class value' do
+          expect(subject.cluster(values_array)).to eq cluster
+        end
+      end
+
+      context 'with a given hash of values' do
+        it 'calls Java’s #cluster_instance' do
+          expect(subject)
+            .to receive(:cluster_instance).once
+            .with(an_instance_of(Weka::Core::DenseInstance))
+
+          subject.cluster(values_hash)
+        end
+
+        it 'returns the predicted class value' do
+          expect(subject.cluster(values_hash)).to eq cluster
         end
       end
 
@@ -297,7 +320,7 @@ describe Weka::Clusterers::Utils do
           subject.cluster(instance)
         end
 
-        it 'returns the predicted class value of the instance' do
+        it 'returns the predicted class value' do
           expect(subject.cluster(instance)).to eq cluster
         end
       end
@@ -308,11 +331,25 @@ describe Weka::Clusterers::Utils do
             .to receive(:cluster_instance).once
             .with(an_instance_of(Weka::Core::DenseInstance))
 
-          subject.cluster(values)
+          subject.cluster(values_array)
         end
 
-        it 'returns the predicted class value of the instance' do
-          expect(subject.cluster(values)).to eq cluster
+        it 'returns the predicted class value' do
+          expect(subject.cluster(values_array)).to eq cluster
+        end
+      end
+
+      context 'with a given hash of values' do
+        it 'calls Java’s #cluster_instance' do
+          expect(subject)
+            .to receive(:cluster_instance).once
+            .with(an_instance_of(Weka::Core::DenseInstance))
+
+          subject.cluster(values_hash)
+        end
+
+        it 'returns the predicted class value' do
+          expect(subject.cluster(values_hash)).to eq cluster
         end
       end
 
@@ -328,8 +365,17 @@ describe Weka::Clusterers::Utils do
   end
 
   describe '#distribution_for' do
-    let(:instance)      { instances.first }
-    let(:values)        { [:overcast, 83, 86, :FALSE, :yes] }
+    let(:instance)     { instances.first }
+    let(:values_array) { [:overcast, 83, 86, :FALSE, :yes] }
+    let(:values_hash) do
+      {
+        outlook: :overcast,
+        temperature: 83,
+        humidity: 86,
+        windy: :FALSE,
+        play: :yes
+      }
+    end
     let(:distributions) { [0.543684388757196, 0.4563156112428039] }
 
     context 'for a newly built clusterer' do
@@ -348,7 +394,7 @@ describe Weka::Clusterers::Utils do
           subject.distribution_for(instance)
         end
 
-        it 'returns the predicted cluster distributions of the instance' do
+        it 'returns the predicted cluster distributions' do
           expect(subject.distribution_for(instance)).to eq distributions
         end
       end
@@ -359,11 +405,25 @@ describe Weka::Clusterers::Utils do
             .to receive(:distribution_for_instance).once
             .with(an_instance_of(Weka::Core::DenseInstance))
 
-          subject.distribution_for(values)
+          subject.distribution_for(values_array)
         end
 
-        it 'returns the predicted cluster distributions of the instance' do
-          expect(subject.distribution_for(values)).to eq distributions
+        it 'returns the predicted cluster distributions' do
+          expect(subject.distribution_for(values_array)).to eq distributions
+        end
+      end
+
+      context 'with a given hash of values' do
+        it 'calls Java’s #distribution_for_instance' do
+          expect(subject)
+            .to receive(:distribution_for_instance).once
+            .with(an_instance_of(Weka::Core::DenseInstance))
+
+          subject.distribution_for(values_hash)
+        end
+
+        it 'returns the predicted cluster distributions' do
+          expect(subject.distribution_for(values_hash)).to eq distributions
         end
       end
 
@@ -402,7 +462,7 @@ describe Weka::Clusterers::Utils do
           subject.distribution_for(instance)
         end
 
-        it 'returns the predicted cluster distributions of the instance' do
+        it 'returns the predicted cluster distributions' do
           expect(subject.distribution_for(instance)).to eq distributions
         end
       end
@@ -413,11 +473,25 @@ describe Weka::Clusterers::Utils do
             .to receive(:distribution_for_instance).once
             .with(an_instance_of(Weka::Core::DenseInstance))
 
-          subject.distribution_for(values)
+          subject.distribution_for(values_array)
         end
 
-        it 'returns the predicted cluster distributions of the instance' do
-          expect(subject.distribution_for(values)).to eq distributions
+        it 'returns the predicted cluster distributions' do
+          expect(subject.distribution_for(values_array)).to eq distributions
+        end
+      end
+
+      context 'with a given hash of values' do
+        it 'calls Java’s #distribution_for_instance' do
+          expect(subject)
+            .to receive(:distribution_for_instance).once
+            .with(an_instance_of(Weka::Core::DenseInstance))
+
+          subject.distribution_for(values_hash)
+        end
+
+        it 'returns the predicted cluster distributions' do
+          expect(subject.distribution_for(values_hash)).to eq distributions
         end
       end
 

--- a/spec/concerns/serializable_spec.rb
+++ b/spec/concerns/serializable_spec.rb
@@ -7,6 +7,12 @@ describe Weka::Concerns::Serializable do
 
   let(:filename) { 'file.model' }
 
+  before do
+    allow(Weka::Core::SerializationHelper)
+      .to receive(:serialize)
+      .and_return(filename)
+  end
+
   it 'responds to #serialize' do
     expect(subject.new).to respond_to :serialize
   end

--- a/spec/core/dense_instance_spec.rb
+++ b/spec/core/dense_instance_spec.rb
@@ -110,7 +110,7 @@ describe Weka::Core::DenseInstance do
     describe '#each_attribute' do
       it 'runs a block on each attribute' do
         subject.each_attribute do |attribute|
-          @result = attribute.name unless @result
+          @result ||= attribute.name
         end
 
         expect(@result).to eq 'outlook'

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -15,6 +15,7 @@ describe Weka::Core::Instances do
   it { is_expected.to respond_to :to_arff }
   it { is_expected.to respond_to :to_csv }
   it { is_expected.to respond_to :to_json }
+  it { is_expected.to respond_to :to_c45 }
 
   it { is_expected.to respond_to :numeric }
   it { is_expected.to respond_to :nominal }
@@ -37,6 +38,7 @@ describe Weka::Core::Instances do
   it { is_expected.to respond_to :serialize }
   it { is_expected.to respond_to :to_m }
   it { is_expected.to respond_to :copy }
+  it { is_expected.to respond_to :instance_from }
 
   describe 'aliases:' do
     let(:instances) { described_class.new }
@@ -840,6 +842,86 @@ describe Weka::Core::Instances do
 
       expect { instances.add_instance(subject.instances.first) }
         .not_to(change { subject.size })
+    end
+  end
+
+  describe '#instance_from' do
+    let(:instance_values) { [1.0, 83.0, 86.0, 1.0, 0.0] }
+    let(:result_values)   { ['overcast', 83.0, 86.0, 'FALSE', 'yes'] }
+    let(:default_weight)  { 1.0 }
+    let(:weight)          { 0.5 }
+
+    context 'with a given array of values' do
+      let(:values) { [:overcast, 83, 86, :FALSE, :yes] }
+
+      it 'returns an instance holding the given values' do
+        instance = subject.instance_from(values)
+
+        expect(instance).to be_kind_of Java::WekaCore::Instance
+        expect(instance.weight).to eq default_weight
+        expect(instance.values).to eq result_values
+      end
+
+      context 'when passing a weight' do
+        it 'returns an instance with the given weight' do
+          instance = subject.instance_from(values, weight: weight)
+
+          expect(instance).to be_kind_of Java::WekaCore::Instance
+          expect(instance.weight).to eq weight
+        end
+      end
+    end
+
+    context 'with a given hash of values' do
+      let(:values) do
+        {
+          outlook: :overcast,
+          temperature: 83,
+          humidity: 86,
+          windy: :FALSE,
+          play: :yes
+        }
+      end
+
+      it 'returns an instance holding the given values' do
+        instance = subject.instance_from(values)
+
+        expect(instance).to be_kind_of Java::WekaCore::Instance
+        expect(instance.weight).to eq default_weight
+        expect(instance.values).to eq result_values
+      end
+
+      context 'when passing a weight' do
+        it 'returns an instance with the given weight' do
+          instance = subject.instance_from(values, weight: weight)
+
+          expect(instance).to be_kind_of Java::WekaCore::Instance
+          expect(instance.weight).to eq weight
+          expect(instance.values).to eq result_values
+        end
+      end
+    end
+
+    context 'with a given instance' do
+      let(:dense_instance) { Weka::Core::DenseInstance.new(instance_values) }
+
+      it 'returns a new instance with the same values' do
+        instance = subject.instance_from(dense_instance)
+
+        expect(instance).to be_kind_of Java::WekaCore::Instance
+        expect(instance.weight).to eq default_weight
+        expect(instance.values).to eq result_values
+      end
+
+      context 'when passing a weight' do
+        it 'returns an instance with the given weight' do
+          instance = subject.instance_from(dense_instance, weight: weight)
+
+          expect(instance).to be_kind_of Java::WekaCore::Instance
+          expect(instance.weight).to eq weight
+          expect(instance.values).to eq result_values
+        end
+      end
     end
   end
 end

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -422,7 +422,7 @@ describe Weka::Core::Instances do
     describe '#each' do
       it 'runs a block on each instance' do
         subject.each do |instance|
-          @result = instance.value(0) unless @result
+          @result ||= instance.value(0)
         end
 
         expect(@result).to eq 0.0 # index of nominal value
@@ -456,7 +456,7 @@ describe Weka::Core::Instances do
     describe '#each_attribute' do
       it 'runs a block on each attribute' do
         subject.each_attribute do |attribute|
-          @result = attribute.name unless @result
+          @result ||= attribute.name
         end
 
         expect(@result).to eq 'outlook'
@@ -839,7 +839,7 @@ describe Weka::Core::Instances do
       expect(instances.to_s).to eq subject.to_s
 
       expect { instances.add_instance(subject.instances.first) }
-        .not_to change { subject.size }
+        .not_to(change { subject.size })
     end
   end
 end

--- a/spec/core/instances_spec.rb
+++ b/spec/core/instances_spec.rb
@@ -36,6 +36,7 @@ describe Weka::Core::Instances do
 
   it { is_expected.to respond_to :serialize }
   it { is_expected.to respond_to :to_m }
+  it { is_expected.to respond_to :copy }
 
   describe 'aliases:' do
     let(:instances) { described_class.new }
@@ -827,6 +828,18 @@ describe Weka::Core::Instances do
       ]
 
       expect(subject.to_m).to eq matrix
+    end
+  end
+
+  describe '#copy' do
+    it 'copies the calling instances' do
+      instances = subject.copy
+
+      expect(instances).to be_kind_of Weka::Core::Instances
+      expect(instances.to_s).to eq subject.to_s
+
+      expect { instances.add_instance(subject.instances.first) }
+        .not_to change { subject.size }
     end
   end
 end

--- a/spec/core/loader_spec.rb
+++ b/spec/core/loader_spec.rb
@@ -13,9 +13,7 @@ describe Weka::Core::Loader do
     method = "load_#{type}"
 
     describe "##{method}" do
-      let(:file) do
-        File.expand_path("../../support/resources/weather.#{type}", __FILE__)
-      end
+      let(:file) { resources_file("weather.#{type}") }
 
       it "returns an Instances object for a given #{type.upcase} file" do
         instances = described_class.send(method, file)
@@ -25,13 +23,8 @@ describe Weka::Core::Loader do
   end
 
   describe '#load_c45' do
-    let(:names_file) do
-      File.expand_path('../../support/resources/weather.names', __FILE__)
-    end
-
-    let(:data_file) do
-      File.expand_path('../../support/resources/weather.data', __FILE__)
-    end
+    let(:names_file) { resources_file('weather.names') }
+    let(:data_file)  { resources_file('weather.data') }
 
     it 'returns an Instances object for a given *.names file' do
       instances = described_class.load_c45(names_file)

--- a/spec/core/saver_spec.rb
+++ b/spec/core/saver_spec.rb
@@ -3,10 +3,9 @@ require 'spec_helper'
 describe Weka::Core::Saver do
   let(:instances) { load_instances('weather.arff') }
 
-  before(:all) { @tmp_dir = File.expand_path('../../tmp/', __FILE__) }
-  after(:all)  { FileUtils.remove_dir(@tmp_dir, true) }
+  after { remove_temp_dir }
 
-  CLASS_METHODS = %i[save_arff save_csv save_json].freeze
+  CLASS_METHODS = %i[save_arff save_csv save_json save_c45].freeze
 
   CLASS_METHODS.each do |method|
     it "responds to .#{method}" do
@@ -18,7 +17,7 @@ describe Weka::Core::Saver do
     method = "save_#{type}"
 
     describe "##{method}" do
-      let(:file) { "#{@tmp_dir}/test.#{type}" }
+      let(:file) { temp_file("test.#{type}") }
 
       it "saves the given Instances to a #{type.upcase} file" do
         expect(File.exist?(file)).to be false
@@ -29,16 +28,10 @@ describe Weka::Core::Saver do
   end
 
   describe '#save_c45' do
-    let(:file)       { "#{@tmp_dir}/test" }
-    let(:names_file) { "#{file}.names" }
-    let(:data_file)  { "#{file}.data" }
+    let(:names_file) { temp_file('test.names') }
+    let(:data_file)  { temp_file('test.data') }
 
     before { instances.class_attribute = :play }
-
-    after do
-      FileUtils.rm_f(names_file)
-      FileUtils.rm_f(data_file)
-    end
 
     it 'creates a *.names file and a *.data file' do
       expect(File.exist?(names_file)).to be false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.include InstancesHelpers
+  config.include FileHelpers
+
+  config.after(:all) { remove_temp_dir }
 end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -1,0 +1,20 @@
+module FileHelpers
+  def temp_dir
+    directory = File.expand_path('../../tmp/', __FILE__)
+    FileUtils.mkdir(directory) unless Dir.exist?(directory)
+    directory
+  end
+
+  def remove_temp_dir
+    FileUtils.remove_dir(temp_dir, true)
+  end
+
+  def temp_file(filename)
+    File.join(temp_dir, filename)
+  end
+
+  def resources_file(filename)
+    path = File.expand_path('../resources/', __FILE__)
+    File.join(path, filename)
+  end
+end

--- a/spec/support/instances_helpers.rb
+++ b/spec/support/instances_helpers.rb
@@ -1,8 +1,10 @@
 module InstancesHelpers
-  def load_instances(file_name)
-    file           = File.expand_path("./../resources/#{file_name}", __FILE__)
-    file_extension = File.extname(file_name)[1..-1]
+  include FileHelpers
 
-    Weka::Core::Loader.send("load_#{file_extension}", file)
+  def load_instances(filename)
+    file      = resources_file(filename)
+    extension = File.extname(filename)[1..-1]
+
+    Weka::Core::Loader.send("load_#{extension}", file)
   end
 end


### PR DESCRIPTION
Fixes #10/#25.

This allows using the `#classify`/`#cluster` and `#distribution_for` methods on deserialized classifiers and clusterers.

When serializing classifiers and clusterers, we now additionally store the structure of the training data in a separate serialized file (named `<filename>.structure`). 

I.e. if you serialize your trained classifier to `classifier.model`, then there will be an additional `classifier.model.structure` file, which holds the header of the training data (info about attributes, class attribute, etc.).

When the classifier/clusterer is deserialized we use this structure file to set the deserialized object’s `instances_structure` attribute, which is used internally to allow passing an array of values to the `#classify`/`#cluster`, and `#distribution_for` methods.

